### PR TITLE
[Feature] Ci: Add release pipeline.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches: [ master, develop, release/** ]
+  pull_request:
+    branches: [ master, develop, release/** ]
 
 jobs:
   unit_tests:

--- a/.github/workflows/commit_lint.yaml
+++ b/.github/workflows/commit_lint.yaml
@@ -1,5 +1,10 @@
 name: Lint Commit Messages
-on: [ push, pull_request ]
+
+on:
+  push:
+    branches: [ master, develop, release/** ]
+  pull_request:
+    branches: [ master, develop, release/** ]
 
 jobs:
   commitlint:

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -1,6 +1,10 @@
 name: Pull Request Labeler
 
-on: [ pull_request_target, push ]
+on:
+  push:
+    branches: [ master, develop, release/** ]
+  pull_request_target:
+    branches: [ master, develop, release/** ]
 
 jobs:
   label:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.github_token }}
+          release-count: 0
+          skip-version-file: true
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+


### PR DESCRIPTION
# Motivation

In order to streamline releases, a release pipeline is needed, to generate a `CHANGELOG.md` and a GitHub release.

Besides that, this PR also fixes the workflow branch triggers, to not run on every pushed commit, rather only on pull requests and pushes on branches which have an associated pull request.

Resolves GH-4

## Proposed changes

- add `.github/workflows/release.yaml`
- change the triggers for all workflows to only run on pushes and pull requests for the `master`, `develop` and `release/**` branches

### Test plan

Since this PR adds and modifies workflows, the CI runs provide sufficient test.
