### PR TITLE
[Hotfix] CI workflows are broken

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -4,6 +4,7 @@ ci: 'ci/*'
 docs: 'docs/*'
 feature: [ 'feature/*', 'feat/*' ]
 fix: 'fix/*'
+hotfix: 'hotfix/*'
 perf: 'perf/*'
 refactor: 'refactor/*'
 revert: 'revert/*'

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -1,8 +1,6 @@
 name: Pull Request Labeler
 
 on:
-  push:
-    branches: [ master, develop, release/** ]
   pull_request_target:
     branches: [ master, develop, release/** ]
 

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -15,6 +15,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - uses: TimonVS/pr-labeler-action@v3
+        name: Label based on head branch name
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
# Motivation

Triggers for `.github/workflows/pr_labeler.yaml` and `.github/workflows/release.yaml` do not work as intended. For the
former, labeling is triggered for pushes, not only pull requests, leading to failures. For the latter, the branch name should be `master`, as the repository does not define a `main` branch.

In order to follow the [Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)
conventions, the `hotfix` label should also be included in the branch based labels, which is done in this commit. The step responsible for this also receives a friendlier name in this commit.

## Proposed changes

- change the triggers for `.github/workflows/pr_labeler.yaml`
- change the triggers for `.github/workflows/release.yaml`
- add the `hotfix` label
- add a friendly name for the branch based labeling step

### Test plan

Existing CI workflows are sufficient

