### PR TITLE
[Hotfix] Changelog step fails due to no checkout.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: Conventional Changelog Action
         id: changelog
         uses: TriPSs/conventional-changelog-action@v3
@@ -20,7 +22,7 @@ jobs:
 
       - name: Create Release
         uses: actions/create-release@v1
-        if: ${{ steps.changelog.outputs.skipped == 'true' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
         with:


### PR DESCRIPTION
# Motivation

Changelog step fails due to no checkout.

## Proposed changes

- add the `checkout` step to the `release` workflow

### Test plan

Existing CI workflows suffice.

