### PR TITLE
[Hotfix] Fetch all history in release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           ref: master
 
       - name: Conventional Changelog Action


### PR DESCRIPTION
Signed-off-by: Filip Dutescu <filip.dutescu@gmail.com>

# Motivation

Fetch all history in release CI.

## Proposed changes

- add `fetch-depth: 0` to the `checkout` step

### Test plan

Existing CI workflows suffice.

