### PR TITLE
[Feature] Docs: `setup` - Add `setup` parameters documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,15 @@ of the settings table.
 
 ```lua
 require('renamer').setup {
+    -- The popup title, shown if `border` is true
     title = 'Rename',
+    -- The padding around the popup content
     padding = { 0, 0, 0, 0 },
+    -- Whether or not to shown a border around the popup
     border = true,
+    -- The characters which make up the border
     border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
+    -- The string to be used as a prompt prefix. It also sets the buffer to be a prompt
     prefix = '',
 }
 ```

--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -31,10 +31,15 @@ renamer.setup({opts})
     Usage:
     >
     require('renamer').setup {
+        -- The popup title, shown if `border` is true
         title = 'Rename',
+        -- The padding around the popup content
         padding = { 0, 0, 0, 0 },
+        -- Whether or not to shown a border around the popup
         border = true,
+        -- The characters which make up the border
         border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
+        -- The string to be used as a prompt prefix. It also sets the buffer to be a prompt
         prefix = '',
     }
 <

--- a/lua/renamer/defaults.lua
+++ b/lua/renamer/defaults.lua
@@ -1,9 +1,13 @@
 local defaults = {
+    -- The popup title, shown if `border` is true
     title = 'Rename',
+    -- The padding around the popup content
     padding = { 0, 0, 0, 0 },
+    -- Whether or not to shown a border around the popup
     border = true,
+    -- The characters which make up the border
     border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
-    -- prefix = '> ',
+    -- The string to be used as a prompt prefix. It also sets the buffer to be a prompt
     prefix = '',
 }
 


### PR DESCRIPTION
# Motivation

Add comments explaining all of the setup options and how they affect the popup. Update the `README.md` and `doc/renamer.txt` files in order to also contain proper documentation in the code sections.

Resolves: GH-11

## Proposed changes

- add doc comments in `lua/renamer/defaults.lua`
- update `README.md` and `doc/renamer.txt` code section docs

### Test plan

Tests are not required for documentation changes.
