### PR TITLE
[Feature] Docs: Add EmmyLua docs.

### DIFF
--- a/lua/renamer/defaults.lua
+++ b/lua/renamer/defaults.lua
@@ -1,3 +1,9 @@
+--- @class Defaults
+--- @field public title string
+--- @field public padding integer[]
+--- @field public border boolean
+--- @field public border_chars string[]
+--- @field public prefix string
 local defaults = {
     -- The popup title, shown if `border` is true
     title = 'Rename',

--- a/lua/renamer/health.lua
+++ b/lua/renamer/health.lua
@@ -4,6 +4,8 @@ local required_plugins = {
     { name = 'plenary' },
 }
 
+--- @class Health
+--- @field public report table Has the reporting functions (e.g. ok, error)
 local health = {}
 health.report = {
     start = vim.fn['health#report_start'],
@@ -18,6 +20,13 @@ health._is_plugin_installed = function(plugin_name)
     return res
 end
 
+--- Checks if all of the required dependecies are installed and if the
+--- `renamer.setup` function was called to initialize the plugin.
+---
+--- Usage:
+--- <code>
+--- require('renamer.health').check()
+--- </code>
 health.check = function()
     health.report.start 'Checking required plugins...'
 

--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -5,8 +5,36 @@ local log = require('plenary.log').new {
 local popup = require 'plenary.popup'
 local utils = require 'renamer.utils'
 
+--- @class Renamer
+--- @field public title string
+--- @field public padding integer[]
+--- @field public border boolean
+--- @field public border_chars string[]
+--- @field public prefix string
+--- @field private _buffers table
 local renamer = {}
 
+--- Setup function to be run by the user. Configures the aspect of the renamer
+--- user interface. Used to change things such as the title or border of the
+--- popup.
+---
+--- Usage:
+--- <code>
+--- require('renamer').setup {
+---     -- The popup title, shown if `border` is true
+---     title = 'Rename',
+---     -- The padding around the popup content
+---     padding = { 0, 0, 0, 0 },
+---     -- Whether or not to shown a border around the popup
+---     border = true,
+---     -- The characters which make up the border
+---     border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
+---     -- The string to be used as a prompt prefix. It also sets the buffer to
+---     -- be a prompt
+---     prefix = '',
+--- }
+--- </code>
+--- @param opts Defaults Configuration options, see `renamer.defaults`.
 function renamer.setup(opts)
     opts = opts or {}
 
@@ -21,6 +49,19 @@ function renamer.setup(opts)
     renamer._buffers = {}
 end
 
+--- Function that renames the word under the cursor, using Neovim's built in
+--- LSP feature (`vim.lsp.buf.rename()`). Creates a popup next to the cursor,
+--- starting at the beginning of the word.
+---
+--- The popup is drawn below the current line, if there is enough space,
+--- otherwise on the one above it.
+---
+--- Usage:
+--- <code>
+--- require('renamer').rename()
+--- </code>
+--- @return integer prompt_window_id
+--- @return table prompt_window_opts @Keys: opts, border_opts
 function renamer.rename()
     local cword = vim.fn.expand '<cword>'
     local line, col = renamer._get_cursor()
@@ -210,9 +251,7 @@ function renamer._delete_autocmds()
     vim.cmd [[augroup end]]
 end
 
--- [[
 -- Since there is no way to mock `vim.lsp.buf.rename`, this function is used as a replacement.
--- ]]
 function renamer._lsp_rename(word)
     vim.lsp.buf.rename(word)
 end


### PR DESCRIPTION
# Motivation

To help users understand how the plugin works and to make it easier to reference documentation while using it, this commit adds EmmyLua documentation comments to the public API functions.

Closes: GH-9

## Proposed changes

- add EmmyLua doc comments to `renamer.setup()`
- add EmmyLua doc comments to `renamer.rename()`
- add EmmyLua doc comments to `renamer.defaults`
- add EmmyLua doc comments to `renamer.health.check()`

### Test plan

Documentation changes do not require tests.
