### PR TITLE
[Feature] CI: Release - Improve GitHub Release name.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github_token }}
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}
-          release_name: ${{ steps.changelog.outputs.tag }}
+          release_name: Renamer.nvim ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
 


### PR DESCRIPTION
# Motivation

To make GitHub Releases friendlier, add the project name to the release name.

Closes: GH-20

## Proposed changes

- change the release name, in `.github/workflow/release.yaml`

### Test plan

The test to validate will be done in the `v0.2.0` release.
