### PR TITLE
[Feature] Add key mappings for easier navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ of the settings table.
 ### Renamer setup structure
 
 ```lua
+local mappings_utils = require('renamer.mappings.utils')
 require('renamer').setup {
     -- The popup title, shown if `border` is true
     title = 'Rename',
@@ -119,8 +120,20 @@ require('renamer').setup {
     border = true,
     -- The characters which make up the border
     border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
-    -- The string to be used as a prompt prefix. It also sets the buffer to be a prompt
+    -- The string to be used as a prompt prefix. It also sets the buffer to
+    -- be a prompt
     prefix = '',
+    -- The keymaps available while in the `renamer` buffer. The example below
+    -- overrides the default values, but you can add others as well.
+    mappings = {
+        ['<c-i>'] = mappings_utils.set_cursor_to_start,
+        ['<c-a>'] = mappings_utils.set_cursor_to_end,
+        ['<c-e>'] = mappings_utils.set_cursor_to_word_end,
+        ['<c-b>'] = mappings_utils.set_cursor_to_word_start,
+        ['<c-c>'] = mappings_utils.clear_line,
+        ['<c-u>'] = mappings_utils.undo,
+        ['<c-r>'] = mappings_utils.redo,
+    },
 }
 ```
 
@@ -135,7 +148,19 @@ hi default link RenamerPrefix Identifier
 
 ## Default mappings
 
-TODO - Should add mappings to make it easy to edit and select text in the prompt.
+Mappings are fully customizable. The default mappings are intended to be familiar
+to users and mimic the default behaviour of their normal mode equivalents.
+
+| Mappings | Action                       |
+|----------|------------------------------|
+| `<c-i>`  | Go to the start of the line. |
+| `<c-a>`  | Go to the end of the line.   |
+| `<c-e>`  | Go to the end of the word.   |
+| `<c-b>`  | Go to the start of the word. |
+| `<c-c>`  | Clear the buffer line.       |
+| `<c-u>`  | Undo changes.                |
+| `<c-r>`  | Redo undone changes.         |
+
 
 ## Media
 

--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -17,6 +17,7 @@ https://github.com/filipdutescu/renamer.nvim
 
   :h renamer.setup
   :h renamer.rename
+  :h renamer.mappings
 
 
 
@@ -30,6 +31,7 @@ renamer.setup({opts})
 
     Usage:
     >
+    local mappings_utils = require('renamer.mappings.utils')
     require('renamer').setup {
         -- The popup title, shown if `border` is true
         title = 'Rename',
@@ -39,8 +41,20 @@ renamer.setup({opts})
         border = true,
         -- The characters which make up the border
         border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
-        -- The string to be used as a prompt prefix. It also sets the buffer to be a prompt
+        -- The string to be used as a prompt prefix. It also sets the buffer to
+        -- be a prompt
         prefix = '',
+        -- The keymaps available while in the `renamer` buffer. The example below
+        -- overrides the default values, but you can add others as well.
+        mappings = {
+            ['<c-i>'] = mappings_utils.set_cursor_to_start,
+            ['<c-a>'] = mappings_utils.set_cursor_to_end,
+            ['<c-e>'] = mappings_utils.set_cursor_to_word_end,
+            ['<c-b>'] = mappings_utils.set_cursor_to_word_start,
+            ['<c-c>'] = mappings_utils.clear_line,
+            ['<c-u>'] = mappings_utils.undo,
+            ['<c-r>'] = mappings_utils.redo,
+        },
     }
 <
 
@@ -69,6 +83,10 @@ renamer.setup({opts})
         {prefix}        (string)    the character to be used as a prompt
                                     prefix (default: '', meaning the popup is
                                     not defined as a prompt)
+        {mappings}      (table)     the keymaps that should be available in
+                                    the buffer, alongside their respective
+                                    actions (default: see
+                                    |lua/renamer/mappings/init.lua|)
 
 
 
@@ -87,6 +105,62 @@ renamer.rename()
    Usage:
    >
    require('renamer').rename()
-<
+
+
+
+
+===============================================================================
+                                                             *renamer.mappings*
+
+Mappings are different key combinations used to help you navigate the `renamer`
+buffer window. The following are mapped by default and can be overriden as
+described in |renamer.setup|:
+
+                                                                        *<c-i>*
+<c-i>               Go to the start of the line (or buffer, since it only
+                    contains one line). Behind the scenes, it uses the "I"
+                    normal mode keymap.
+
+                        See `:help I`
+
+                                                                        *<c-a>*
+<c-a>               Go to the end of the line (or buffer, since it only
+                    contains one line). Behind the scenes, it uses the "A"
+                    normal mode keymap.
+
+                        See `:help A`
+
+                                                                        *<c-e>*
+<c-e>               Go to the end of the word currently under the cursor.
+                    Behind the scenes, it uses the "e" normal mode keymap.
+
+                        See `:help e`
+
+                                                                        *<c-b>*
+<c-b>               Go to the beginning of the word currently under the
+                    cursor. Behind the scenes, it uses the "b" normal mode
+                    keymap.
+
+                        See `:help b`
+
+                                                                        *<c-c>*
+<c-c>               Clears the line (or buffer, since it only contains one
+                    line). Behind the scenes, it uses the "0C" normal mode
+                    keymaps.
+
+                        See `:help 0`, `:help C`
+
+                                                                        *<c-u>*
+<c-u>               Undo changes. Behind the scenes, it uses the "u" normal
+                    mode keymap.
+
+                        See `:help u`
+
+                                                                        *<c-r>*
+<c-r>               Redo changes that were undone. Behind the scenes, it uses
+                    the "<c-r>" normal mode keymap.
+
+                        See ``:help CTRL-R`
+
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/lua/renamer/defaults.lua
+++ b/lua/renamer/defaults.lua
@@ -1,9 +1,12 @@
+local mappings = require 'renamer.mappings'
+
 --- @class Defaults
 --- @field public title string
 --- @field public padding integer[]
 --- @field public border boolean
 --- @field public border_chars string[]
 --- @field public prefix string
+--- @field public mappings string
 local defaults = {
     -- The popup title, shown if `border` is true
     title = 'Rename',
@@ -13,8 +16,12 @@ local defaults = {
     border = true,
     -- The characters which make up the border
     border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
-    -- The string to be used as a prompt prefix. It also sets the buffer to be a prompt
+    -- The string to be used as a prompt prefix. It also sets the buffer to
+    -- be a prompt
     prefix = '',
+    -- The keymaps available while in the `renamer` buffer. The example below
+    -- overrides the default values, but you can add others as well.
+    mappings = mappings.bindings,
 }
 
 return defaults

--- a/lua/renamer/mappings/init.lua
+++ b/lua/renamer/mappings/init.lua
@@ -1,0 +1,40 @@
+local utils = require 'renamer.mappings.utils'
+
+--- @class Mappings
+--- @field public bindings table
+--- @field public keymap_opts table
+local mappings = {
+    bindings = {
+        ['<c-i>'] = utils.set_cursor_to_start,
+        ['<c-a>'] = utils.set_cursor_to_end,
+        ['<c-e>'] = utils.set_cursor_to_word_end,
+        ['<c-b>'] = utils.set_cursor_to_word_start,
+        ['<c-c>'] = utils.clear_line,
+        ['<c-u>'] = utils.undo,
+        ['<c-r>'] = utils.redo,
+    },
+    keymap_opts = {
+        noremap = true,
+        silent = true,
+    },
+}
+
+mappings.register_bindings = function(buf_id)
+    if buf_id and mappings.bindings then
+        for binding, _ in pairs(mappings.bindings) do
+            local action = string.format(
+                '<cmd>lua require("renamer.mappings").exec_keymap_action("%s")<cr>',
+                binding:gsub('<', '<lt>')
+            )
+            vim.api.nvim_buf_set_keymap(buf_id, 'i', binding, action, mappings.keymap_opts)
+        end
+    end
+end
+
+mappings.exec_keymap_action = function(binding)
+    if binding and mappings.bindings and mappings.bindings[binding] then
+        mappings.bindings[binding]()
+    end
+end
+
+return mappings

--- a/lua/renamer/mappings/utils.lua
+++ b/lua/renamer/mappings/utils.lua
@@ -1,0 +1,45 @@
+local utils = {}
+
+utils.exec_in_normal = function(callback, opts, ...)
+    vim.cmd [[stopinsert]]
+    callback(...)
+
+    if opts and opts.keep_insert then
+        vim.api.nvim_feedkeys('i', 'n', true)
+    end
+end
+
+utils.set_cursor_to_end = function()
+    utils.exec_in_normal(vim.api.nvim_feedkeys, {}, 'A', 'n', true)
+end
+
+utils.set_cursor_to_start = function()
+    utils.exec_in_normal(vim.api.nvim_feedkeys, {}, 'I', 'n', true)
+end
+
+utils.set_cursor_to_word_end = function()
+    utils.exec_in_normal(vim.api.nvim_feedkeys, { keep_insert = true }, 'e', 'n', true)
+end
+
+utils.set_cursor_to_word_start = function()
+    utils.exec_in_normal(vim.api.nvim_feedkeys, { keep_insert = true }, 'b', 'n', true)
+end
+
+utils.clear_line = function()
+    utils.exec_in_normal(vim.api.nvim_feedkeys, { keep_insert = true }, '0C', 'n', true)
+end
+
+utils.undo = function()
+    utils.exec_in_normal(vim.api.nvim_feedkeys, { keep_insert = true }, 'u', 't', true)
+end
+
+utils.redo = function()
+    utils.exec_in_normal(function()
+        local key = vim.api.nvim_replace_termcodes('<c-r>', true, false, true)
+        vim.api.nvim_feedkeys(key, 't', true)
+    end, {
+        keep_insert = true,
+    })
+end
+
+return utils

--- a/lua/tests/mappings/mappings_defaults_spec.lua
+++ b/lua/tests/mappings/mappings_defaults_spec.lua
@@ -1,0 +1,20 @@
+local mappings = require 'renamer.mappings'
+
+local eq = assert.are.same
+
+describe('mappings', function()
+    it('should have actions initialized for all `bindings`', function()
+        local bindings = mappings.bindings
+
+        for key, value in pairs(bindings) do
+            assert(value, string.format('No action mapped to "%s".', key))
+        end
+    end)
+
+    it('should have `keymap_opts` initialized', function()
+        local expected_opts = { noremap = true, silent = true }
+        local keymap_opts = mappings.keymap_opts
+
+        eq(expected_opts, keymap_opts)
+    end)
+end)

--- a/lua/tests/mappings/mappings_exec_keymap_action_spec.lua
+++ b/lua/tests/mappings/mappings_exec_keymap_action_spec.lua
@@ -1,0 +1,37 @@
+local mappings = require 'renamer.mappings'
+
+local stub = require 'luassert.stub'
+
+local eq = assert.are.same
+
+describe('mappings', function()
+    describe('exec_keymap_action', function()
+        it('should not execute if `keymap` is nil', function()
+            local binding = '<c-a>'
+            local initial_action = mappings.bindings[binding]
+            local was_called = false
+            mappings.bindings[binding] = function()
+                was_called = true
+            end
+
+            mappings.exec_keymap_action()
+
+            eq(false, was_called)
+            mappings.bindings[binding] = initial_action
+        end)
+
+        it('should execute the action associated with a valid binding', function()
+            local binding = '<c-a>'
+            local initial_action = mappings.bindings[binding]
+            local was_called = false
+            mappings.bindings[binding] = function()
+                was_called = true
+            end
+
+            mappings.exec_keymap_action(binding)
+
+            eq(true, was_called)
+            mappings.bindings[binding] = initial_action
+        end)
+    end)
+end)

--- a/lua/tests/mappings/mappings_register_bindings_spec.lua
+++ b/lua/tests/mappings/mappings_register_bindings_spec.lua
@@ -1,0 +1,55 @@
+local mappings = require 'renamer.mappings'
+
+local stub = require 'luassert.stub'
+
+describe('mappings', function()
+    describe('register_bindings', function()
+        it('should not set keymaps if `buf_id` is nil', function()
+            local set_keymap = stub(vim.api, 'nvim_buf_set_keymap')
+
+            mappings.register_bindings()
+
+            assert.spy(set_keymap).called_less_than(1)
+        end)
+
+        it('should not set keymaps if `bindings` is nil', function()
+            local buf_id = 1
+            local set_keymap = stub(vim.api, 'nvim_buf_set_keymap')
+            local initial_bindings = mappings.bindings
+            mappings.bindings = nil
+
+            mappings.register_bindings(buf_id)
+
+            assert.spy(set_keymap).called_less_than(1)
+            mappings.bindings = initial_bindings
+        end)
+
+        it('should not set keymaps if `bindings` is empty', function()
+            local buf_id = 1
+            local set_keymap = stub(vim.api, 'nvim_buf_set_keymap')
+            local initial_bindings = mappings.bindings
+            mappings.bindings = {}
+
+            mappings.register_bindings(buf_id)
+
+            assert.spy(set_keymap).called_less_than(1)
+            mappings.bindings = initial_bindings
+        end)
+
+        it('should set `bindings` as keymaps for the received buffer', function()
+            local buf_id = 1
+            local set_keymap = stub(vim.api, 'nvim_buf_set_keymap')
+            local bindings = mappings.bindings
+
+            mappings.register_bindings(buf_id)
+
+            for key, _ in pairs(bindings) do
+                local action = string.format(
+                    '<cmd>lua require("renamer.mappings").exec_keymap_action("%s")<cr>',
+                    key:gsub('<', '<lt>')
+                )
+                assert.spy(set_keymap).was_called_with(buf_id, 'i', key, action, mappings.keymap_opts)
+            end
+        end)
+    end)
+end)

--- a/lua/tests/mappings/utils_spec.lua
+++ b/lua/tests/mappings/utils_spec.lua
@@ -1,0 +1,123 @@
+local utils = require 'renamer.mappings.utils'
+
+local stub = require 'luassert.stub'
+
+local eq = assert.are.same
+
+describe('mappings', function()
+    describe('utils', function()
+        describe('exec_in_normal', function()
+            it('should exit "insert" mode and execute callback (and enter "insert" mode afterwards)', function()
+                local was_called = false
+                local cmd = stub(vim, 'cmd')
+                local nvim_feedkeys = stub(vim.api, 'nvim_feedkeys')
+
+                utils.exec_in_normal(function()
+                    was_called = true
+                end, {
+                    keep_insert = true,
+                })
+
+                eq(true, was_called)
+                assert.spy(cmd).was_called_with [[stopinsert]]
+                assert.spy(nvim_feedkeys).was_called_with('i', 'n', true)
+            end)
+
+            it('should exit "insert" mode and execute callback', function()
+                local was_called = false
+                local cmd = stub(vim, 'cmd')
+
+                utils.exec_in_normal(function()
+                    was_called = true
+                end, {
+                    keep_insert = false,
+                })
+
+                eq(true, was_called)
+                assert.spy(cmd).was_called_with [[stopinsert]]
+                assert.spy(cmd).called_at_most(1)
+            end)
+
+            it('should execute callback with arguments', function()
+                local was_called = false
+
+                utils.exec_in_normal(function(val)
+                    was_called = val
+                end, {}, true)
+
+                eq(true, was_called)
+            end)
+        end)
+
+        describe('set_cursor_to_end', function()
+            it('should call `vim.api.nvim_feedkeys` with "A"', function()
+                local nvim_feedkeys = stub(vim.api, 'nvim_feedkeys')
+
+                utils.set_cursor_to_end()
+
+                assert.spy(nvim_feedkeys).was_called_with('A', 'n', true)
+            end)
+        end)
+
+        describe('set_cursor_to_start', function()
+            it('should call `vim.api.nvim_feedkeys` with "I"', function()
+                local nvim_feedkeys = stub(vim.api, 'nvim_feedkeys')
+
+                utils.set_cursor_to_start()
+
+                assert.spy(nvim_feedkeys).was_called_with('I', 'n', true)
+            end)
+        end)
+
+        describe('set_cursor_to_word_end', function()
+            it('should call `vim.api.nvim_feedkeys` with "e"', function()
+                local nvim_feedkeys = stub(vim.api, 'nvim_feedkeys')
+
+                utils.set_cursor_to_word_end()
+
+                assert.spy(nvim_feedkeys).was_called_with('e', 'n', true)
+            end)
+        end)
+
+        describe('set_cursor_to_word_start', function()
+            it('should call `vim.api.nvim_feedkeys` with "b"', function()
+                local nvim_feedkeys = stub(vim.api, 'nvim_feedkeys')
+
+                utils.set_cursor_to_word_start()
+
+                assert.spy(nvim_feedkeys).was_called_with('b', 'n', true)
+            end)
+        end)
+
+        describe('clear_line', function()
+            it('should call `vim.api.nvim_feedkeys` with "0C"', function()
+                local nvim_feedkeys = stub(vim.api, 'nvim_feedkeys')
+
+                utils.clear_line()
+
+                assert.spy(nvim_feedkeys).was_called_with('0C', 'n', true)
+            end)
+        end)
+
+        describe('undo', function()
+            it('should call `vim.api.nvim_feedkeys` with "u"', function()
+                local nvim_feedkeys = stub(vim.api, 'nvim_feedkeys')
+
+                utils.undo()
+
+                assert.spy(nvim_feedkeys).was_called_with('u', 't', true)
+            end)
+        end)
+
+        describe('redo', function()
+            it('should call `vim.api.nvim_feedkeys` with "<c-r>"', function()
+                local key = vim.api.nvim_replace_termcodes('<c-r>', true, false, true)
+                local nvim_feedkeys = stub(vim.api, 'nvim_feedkeys')
+
+                utils.redo()
+
+                assert.spy(nvim_feedkeys).was_called_with(key, 't', true)
+            end)
+        end)
+    end)
+end)

--- a/lua/tests/renamer_rename_spec.lua
+++ b/lua/tests/renamer_rename_spec.lua
@@ -115,5 +115,22 @@ describe('renamer', function()
             eq(expected_border_opts, opts.border_opts)
             mock.revert(api_mock)
         end)
+
+        it('should call `mappings.register_bindings`', function()
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_cursor.returns { 1, 2 }
+            api_mock.nvim_command.returns()
+            api_mock.nvim_buf_line_count.returns(1)
+            api_mock.nvim_get_mode.returns {}
+            local mappings = require 'renamer.mappings'
+            local register_bindings = spy.on(mappings, 'register_bindings')
+            stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+            stub(popup, 'create').returns(1, {})
+
+            renamer.rename()
+
+            assert.spy(register_bindings).was_called()
+            mock.revert(api_mock)
+        end)
     end)
 end)

--- a/lua/tests/renamer_setup_spec.lua
+++ b/lua/tests/renamer_setup_spec.lua
@@ -7,6 +7,7 @@ describe('renamer', function()
         local defaults = require 'renamer.defaults'
 
         it('should use defaults if no options are passed', function()
+            local mappings = require 'renamer.mappings'
             renamer.setup()
 
             eq(defaults.title, renamer.title)
@@ -14,10 +15,12 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(defaults.prefix, renamer.prefix)
+            eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
 
         it('should use defaults where no options are passed ("title" passed)', function()
+            local mappings = require 'renamer.mappings'
             local opts = {
                 title = 'abc',
             }
@@ -29,10 +32,12 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(defaults.prefix, renamer.prefix)
+            eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
 
         it('should use defaults where no options are passed ("padding" passed)', function()
+            local mappings = require 'renamer.mappings'
             local opts = {
                 padding = { 1, 2, 3, 4 },
             }
@@ -44,10 +49,12 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(defaults.prefix, renamer.prefix)
+            eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
 
         it('should use defaults where no options are passed ("border" passed)', function()
+            local mappings = require 'renamer.mappings'
             local opts = {
                 border = true,
             }
@@ -59,10 +66,12 @@ describe('renamer', function()
             eq(opts.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(defaults.prefix, renamer.prefix)
+            eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
 
         it('should use defaults where no options are passed ("border_chars" passed)', function()
+            local mappings = require 'renamer.mappings'
             local opts = {
                 border_chars = { '═', '║', '═', '║', '╔', '╗', '╝', '╚' },
             }
@@ -74,10 +83,12 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(opts.border_chars, renamer.border_chars)
             eq(defaults.prefix, renamer.prefix)
+            eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
 
         it('should use defaults where no options are passed ("prefix" passed)', function()
+            local mappings = require 'renamer.mappings'
             local opts = {
                 prefix = '> ',
             }
@@ -89,16 +100,40 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(opts.prefix, renamer.prefix)
+            eq(defaults.mappings, mappings.bindings)
+            eq({}, renamer._buffers)
+        end)
+
+        it('should use defaults where no options are passed ("mappings" passed)', function()
+            local mappings = require 'renamer.mappings'
+            local opts = {
+                mappings = {
+                    ['<c-a>'] = 'test',
+                },
+            }
+
+            renamer.setup(opts)
+
+            eq(defaults.title, renamer.title)
+            eq(defaults.padding, renamer.padding)
+            eq(defaults.border, renamer.border)
+            eq(defaults.border_chars, renamer.border_chars)
+            eq(defaults.prefix, renamer.prefix)
+            eq(opts.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
 
         it('should use options if passed', function()
+            local mappings = require 'renamer.mappings'
             local opts = {
                 title = 'abc',
                 padding = { 1, 2, 3, 4 },
                 border = true,
                 border_chars = { '═', '║', '═', '║', '╔', '╗', '╝', '╚' },
                 prefix = '> ',
+                mappings = {
+                    ['<c-a>'] = 'test',
+                },
             }
 
             renamer.setup(opts)
@@ -108,6 +143,7 @@ describe('renamer', function()
             eq(opts.border, renamer.border)
             eq(opts.border_chars, renamer.border_chars)
             eq(opts.prefix, renamer.prefix)
+            eq(opts.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
     end)


### PR DESCRIPTION
 Motivation

To make it easier to navigate the buffer and manipulate its contents,
this commit adds a set of default keymaps, which provide basic
navigation:

- `<c-i>`, sets the cursor to the start
- `<c-a>`, sets the cursor to the end
- `<c-e>`, sets the cursor to the word end
- `<c-b>`, sets the cursor to the word start
- `<c-c>`, clears the line
- `<c-u>`, undo changes
- `<c-r>`, redo undone changes

Closes: GH-3

## Proposed changes

- add `lua/renamer/mappings` for easier management
- add mappings to `lua/renamer/defaults`
- register mappings per buffer in `renamer._setup_window()`
- update docs

### Test plan

Existing tests are updated to take into account the new feature and `lua/tests/mappings/*` cover the rest.
