### PR TITLE
[Fix] Keymaps: `<c-c>` added an `i` after clear.

### DIFF
--- a/lua/renamer/mappings/utils.lua
+++ b/lua/renamer/mappings/utils.lua
@@ -26,7 +26,7 @@ utils.set_cursor_to_word_start = function()
 end
 
 utils.clear_line = function()
-    utils.exec_in_normal(vim.api.nvim_feedkeys, { keep_insert = true }, '0C', 'n', true)
+    utils.exec_in_normal(vim.api.nvim_feedkeys, {}, '0C', 'n', true)
 end
 
 utils.undo = function()


### PR DESCRIPTION
# Motivation

Since `<c-c>` uses the `0C` normal mode keymaps behind the scenes and `C` puts the user in `insert` mode, there is no need to re-enter it.

The fix in this case is not to set `keep_insert` to `true`, in the `exec_in_normal()` parameters, from `require('renamer.mappings.utils').clear_line()`.

Closes: GH-30

## Proposed changes

- remove `{ keep_insert = true }` from the `exec_in_normal()` call of `clear_line()`

### Test plan

Existing tests cover the changes.

