### PR TITLE
[Fix] Cursor placement when finishing `rename()`.

### DIFF
--- a/lua/tests/renamer_rename_spec.lua
+++ b/lua/tests/renamer_rename_spec.lua
@@ -89,8 +89,8 @@ describe('renamer', function()
         end)
 
         it('should return the buffer ID and the popup options', function()
-            local expected_col_no = 2
-            local expected_line_no = 2
+            local expected_col_no, expected_line_no = 2, 2
+            local word_start = 1
             local expected_opts = {
                 title = renamer.title,
                 padding = renamer.padding,
@@ -105,11 +105,16 @@ describe('renamer', function()
                 cursor_line = true,
                 enter = true,
                 initial_mode = 'test',
+                initial_pos = {
+                    word_start = word_start,
+                    col = expected_col_no,
+                    line = expected_line_no,
+                },
             }
             local expected_border_opts = {}
             local expected_buf_id = 123
             local api_mock = mock(vim.api, true)
-            api_mock.nvim_win_get_cursor.returns { 1, expected_col_no }
+            api_mock.nvim_win_get_cursor.returns { expected_line_no, expected_col_no }
             api_mock.nvim_command.returns()
             api_mock.nvim_buf_line_count.returns(expected_line_no + 5)
             api_mock.nvim_get_mode.returns { mode = expected_opts.initial_mode }


### PR DESCRIPTION
# Motivation

cdb40c6 (GH-33) introduced a bug which made the cursor go 1 character back when finishing the `rename()` call (by cancellation or submission).

To fix this, the popup options also contain various information regarding the starting position (where the word starts and the cursor position at the moment of the call). This makes is easy to update `on_close()` to set the cursor at the initial position on cancellation (behaviour toggled by a new parameter).

This PR also makes it so as, upon submission of the rename, the cursor is placed at the end of the new word, by copying the current implementation of `vim.lsp.buf.rename()`. The new `_lsp_rename` method makes LSP requests in the same way Neovim implements the rename feature and uses a callback to asynchronously set the cursor position.

Fixes: GH-34

## Proposed changes

- add `initial_pos` to `renamer._buffers[x].opts`, containing the initial `word_start`, cursor `col` and `line`
- update `on_close` to receive an extra parameter (by default `true`) which tells it to set the cursor position to the initial one
- update `on_submit` to call `on_close` with the new parameter set to `false` and give the `initial_pos` to the `_lsp_rename()` call
- update `_lsp_rename()` to asynchronously make LSP requests for `textDocument/prepareRename` and `textDocument/rename`, instead of using `vim.lsp.buf.rename()` and set the last request callback to a function setting the cursor position to the end of the renamed word

### Test plan

Existing tests are updated to cover the new functionality and 2 new test cases are added to `lua/tests/renamer_close_spec.lua`, which cover the cancellation and submission behaviour.
