### PR TITLE
[Fix] Cursor position when cancelled from `insert`

### DIFF
--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -167,7 +167,11 @@ function renamer.on_close(window_id, should_set_cursor_pos)
     end
 
     if should_set_cursor_pos and pos then
-        vim.api.nvim_win_set_cursor(0, { pos.line, pos.col + 1 })
+        local col = pos.col
+        if initial_mode and not string.match(initial_mode, 'i') then
+            col = col + 1
+        end
+        vim.api.nvim_win_set_cursor(0, { pos.line, col })
     end
 end
 
@@ -301,6 +305,10 @@ function renamer._lsp_rename(word, pos)
 
             if pos then
                 local col = pos.word_start + #word - 1
+                local mode = vim.api.nvim_get_mode().mode
+                if mode and not string.match(mode, 'i') then
+                    col = col - 1
+                end
                 vim.api.nvim_win_set_cursor(0, { pos.line, col })
             end
         end)

--- a/lua/tests/renamer_close_spec.lua
+++ b/lua/tests/renamer_close_spec.lua
@@ -396,21 +396,47 @@ describe('renamer', function()
             clear_references.revert(clear_references)
         end)
 
-        it('should set cursor in the initial position (when `rename()` is cancelled)', function()
-            local expected_win_id = 123
-            local api_mock = mock(vim.api, true)
-            api_mock.nvim_win_is_valid.returns(false)
-            api_mock.nvim_command.returns()
-            api_mock.nvim_win_set_cursor.returns()
-            local clear_references = stub(renamer, '_clear_references').returns()
-            local expected_pos = { col = 1, line = 1 }
-            renamer._buffers[expected_win_id] = { opts = { initial_pos = expected_pos } }
+        it(
+            'should set cursor in the initial position (when `rename()` is cancelled) (initial mode: `normal`)',
+            function()
+                local expected_win_id = 123
+                local api_mock = mock(vim.api, true)
+                api_mock.nvim_win_is_valid.returns(false)
+                api_mock.nvim_command.returns()
+                api_mock.nvim_win_set_cursor.returns()
+                local clear_references = stub(renamer, '_clear_references').returns()
+                local expected_pos = { col = 1, line = 1 }
+                renamer._buffers[expected_win_id] = { opts = { initial_mode = 'n', initial_pos = expected_pos } }
 
-            renamer.on_close(expected_win_id)
+                renamer.on_close(expected_win_id)
 
-            assert.spy(api_mock.nvim_win_set_cursor).was_called_with(0, { expected_pos.line, expected_pos.col + 1 })
-            mock.revert(api_mock)
-            clear_references.revert(clear_references)
-        end)
+                assert.spy(api_mock.nvim_win_set_cursor).was_called_with(0, {
+                    expected_pos.line,
+                    expected_pos.col + 1,
+                })
+                mock.revert(api_mock)
+                clear_references.revert(clear_references)
+            end
+        )
+
+        it(
+            'should set cursor in the initial position (when `rename()` is cancelled) (initial mode: `insert`)',
+            function()
+                local expected_win_id = 123
+                local api_mock = mock(vim.api, true)
+                api_mock.nvim_win_is_valid.returns(false)
+                api_mock.nvim_command.returns()
+                api_mock.nvim_win_set_cursor.returns()
+                local clear_references = stub(renamer, '_clear_references').returns()
+                local expected_pos = { col = 1, line = 1 }
+                renamer._buffers[expected_win_id] = { opts = { initial_mode = 'i', initial_pos = expected_pos } }
+
+                renamer.on_close(expected_win_id)
+
+                assert.spy(api_mock.nvim_win_set_cursor).was_called_with(0, { expected_pos.line, expected_pos.col })
+                mock.revert(api_mock)
+                clear_references.revert(clear_references)
+            end
+        )
     end)
 end)


### PR DESCRIPTION
# Motivation

In `insert` mode, when cancelling `rename()` was cancelled, the cursor is put one character ahead of its initial position, as a result of cdcdb17. This PR fixes the issue by checking for the initial mode in which `rename()` was called, for `on_close()` or by getting the current mode and checking it, for `on_submit()`.

Fixes: GH-37

## Proposed changes

- check for the `initial_mode` in `on_close` and determine whether or not to add `1` to the initial column position
- check for the current mode in `on_submit` and determine whether or not to go back an additional character (for non `insert` modes, this puts the cursor on the last character of the new word)
- add tests

### Test plan

Existing tests are updated to cover the new functionality and 2 new test cases are added in `lua/tests/renamer_close_spec.lua`, to check for the `normal` and `insert` mode behaviour of `on_close` (as `on_submit` is tricky to test and I am not sure how to do it for the time being).