### PR TITLE
feat(highlighting): add popup title highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ following highlight groups can also be modified to theme the popup colours:
 ```viml
 hi default link RenamerNormal Normal
 hi default link RenamerBorder RenamerNormal
+hi default link RenamerTitle Identifier
 hi default link RenamerPrefix Identifier
 ```
 

--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -100,6 +100,7 @@ function renamer.rename()
 
     local popup_opts = {
         title = renamer.title,
+        titlehighlight = 'RenamerTitle',
         padding = renamer.padding,
         border = renamer.border,
         borderchars = renamer.border_chars,

--- a/lua/tests/renamer_rename_spec.lua
+++ b/lua/tests/renamer_rename_spec.lua
@@ -130,6 +130,7 @@ describe('renamer', function()
             local word_start = 1
             local expected_opts = {
                 title = renamer.title,
+                titlehighlight = 'RenamerTitle',
                 padding = renamer.padding,
                 border = renamer.border,
                 borderchars = renamer.border_chars,

--- a/plugin/renamer.vim
+++ b/plugin/renamer.vim
@@ -10,5 +10,6 @@ let g:loaded_renamer = 1
 
 hi default link RenamerNormal Normal
 hi default link RenamerBorder RenamerNormal
+hi default link RenamerTitle Identifier
 hi default link RenamerPrefix Identifier
 


### PR DESCRIPTION
# Motivation

Add a new highlighting group, `RenamerTitle`, used to set the colour of the popup title. This option was already exposed by `plenary.nvim`'s popup component.

Closes: GH-45

## Proposed changes

- add the `RenamerTitle` to `plugin/renamer.vim`
- add the `titlehighlight` options in `renamer.rename()`
- update `README.md`

### Test plan

Existing tests are updated to cover the new behaviour.
