### PR TITLE
fix: position when word appears multiple times

### DIFF
--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -83,7 +83,7 @@ end
 function renamer.rename()
     local cword = vim.fn.expand '<cword>'
     local line, col = renamer._get_cursor()
-    local word_start, _ = renamer._get_word_boundaries_in_line(vim.api.nvim_get_current_line(), cword, col)
+    local word_start, _ = utils.get_word_boundaries_in_line(vim.api.nvim_get_current_line(), cword, col + 1)
     local prompt_col_no, prompt_line_no = col - word_start + 1, 2
     local lines_from_win_end = vim.api.nvim_buf_line_count(0) - line
     local border_highlight = 'RenamerBorder'
@@ -186,18 +186,6 @@ function renamer._get_cursor()
     local cursor = vim.api.nvim_win_get_cursor(0)
 
     return cursor[1], cursor[2]
-end
-
-function renamer._get_word_boundaries_in_line(line, word, line_pos)
-    local i = 1
-    local word_start, word_end = string.find(line, word, line_pos - i)
-
-    while word_end == nil or line_pos - i < 0 do
-        i = i + 1
-        word_start, word_end = string.find(line, word, line_pos - i)
-    end
-
-    return word_start, word_end
 end
 
 function renamer._setup_window(prompt_win_id)

--- a/lua/renamer/utils.lua
+++ b/lua/renamer/utils.lua
@@ -13,4 +13,34 @@ function utils.get_value_or_default(table, name, default)
     end
 end
 
+function utils.get_word_boundaries_in_line(line, word, line_pos)
+    local len = string.len(line)
+    if line_pos > len then
+        return nil, nil
+    end
+    local i = 1
+    local word_start, word_end = string.find(line, word, i)
+    local closest_word_start, closest_word_end = word_start, word_end
+
+    while i <= len do
+        i = i + 1
+        word_start, word_end = string.find(line, word, i)
+
+        if
+            word_start
+            and word_end
+            and math.abs(line_pos - word_start) < math.abs(line_pos - closest_word_start)
+            and math.abs(word_end - line_pos) < math.abs(closest_word_end - line_pos)
+        then
+            closest_word_start, closest_word_end = word_start, word_end
+        end
+    end
+
+    if closest_word_start and closest_word_end and (closest_word_start > line_pos or closest_word_end < line_pos) then
+        return nil, nil
+    end
+
+    return closest_word_start, closest_word_end
+end
+
 return utils

--- a/lua/tests/renamer_layout_spec.lua
+++ b/lua/tests/renamer_layout_spec.lua
@@ -1,4 +1,5 @@
 local renamer = require 'renamer'
+local utils = require 'renamer.utils'
 
 local popup = require 'plenary.popup'
 
@@ -22,7 +23,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 local set_prompt_border_win_style = spy.on(renamer, '_set_prompt_border_win_style')
-                stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, { border = { win_id = 1 } })
 
@@ -42,7 +43,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(cursor_line + expected_line_no + 1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -61,7 +62,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -80,7 +81,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(expected_col_no, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(expected_col_no, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -100,7 +101,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(cursor_col, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(cursor_col, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -121,7 +122,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(word_start, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(word_start, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -147,7 +148,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(cursor_line + expected_line_no + 1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -166,7 +167,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -185,7 +186,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(expected_col_no + 1, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(expected_col_no + 1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -205,7 +206,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(cursor_col + 1, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(cursor_col + 1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -226,7 +227,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
-                stub(renamer, '_get_word_boundaries_in_line').returns(word_start, 2)
+                stub(utils, 'get_word_boundaries_in_line').returns(word_start, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 

--- a/lua/tests/renamer_rename_spec.lua
+++ b/lua/tests/renamer_rename_spec.lua
@@ -1,4 +1,5 @@
 local renamer = require 'renamer'
+local utils = require 'renamer.utils'
 
 local popup = require 'plenary.popup'
 
@@ -23,13 +24,13 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
             stub(vim.fn, 'expand').returns 'test'
-            local get_word_boundaries_in_line = stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+            local get_word_boundaries_in_line = stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
             stub(popup, 'create').returns(1, {})
 
             renamer.rename()
 
-            assert.spy(get_word_boundaries_in_line).was_called_with(expected_line, expected_cword, expected_col)
+            assert.spy(get_word_boundaries_in_line).was_called_with(expected_line, expected_cword, expected_col + 1)
             mock.revert(api_mock)
             document_highlight.revert(document_highlight)
         end)
@@ -41,7 +42,7 @@ describe('renamer', function()
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_get_mode.returns {}
             spy.on(renamer, '_setup_window')
-            stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight_internal')
             stub(popup, 'create').returns(1, {})
 
@@ -59,7 +60,7 @@ describe('renamer', function()
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_get_mode.returns {}
             spy.on(renamer, '_setup_window')
-            stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             renamer.setup { show_refs = false }
             local document_highlight = stub(renamer, '_document_highlight_internal')
             stub(popup, 'create').returns(1, {})
@@ -78,7 +79,7 @@ describe('renamer', function()
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_get_mode.returns {}
             local setup_window = spy.on(renamer, '_setup_window')
-            stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
             stub(popup, 'create').returns(1, {})
 
@@ -96,7 +97,7 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
             local set_prompt_win_style = spy.on(renamer, '_set_prompt_win_style')
-            stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
             stub(popup, 'create').returns(1, {})
 
@@ -114,7 +115,7 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
             local create_autocms = spy.on(renamer, '_create_autocmds')
-            stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
             stub(popup, 'create').returns(1, {})
 
@@ -156,7 +157,7 @@ describe('renamer', function()
             api_mock.nvim_command.returns()
             api_mock.nvim_buf_line_count.returns(expected_line_no + 5)
             api_mock.nvim_get_mode.returns { mode = expected_opts.initial_mode }
-            stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
             stub(popup, 'create').returns(expected_buf_id, { border = expected_border_opts })
 
@@ -177,7 +178,7 @@ describe('renamer', function()
             api_mock.nvim_get_mode.returns {}
             local mappings = require 'renamer.mappings'
             local register_bindings = spy.on(mappings, 'register_bindings')
-            stub(renamer, '_get_word_boundaries_in_line').returns(1, 2)
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
             stub(popup, 'create').returns(1, {})
 

--- a/lua/tests/utils_spec.lua
+++ b/lua/tests/utils_spec.lua
@@ -33,4 +33,50 @@ describe('utils', function()
             eq(expected_value, result)
         end)
     end)
+
+    describe('get_word_boundaries_in_line', function()
+        it('should return the word start and end positions (with position outside word)', function()
+            local word = 'abc'
+            local line = 'test ' .. word .. ' test'
+            local expected_word_start, expected_word_end = nil, nil
+
+            local word_start, word_end = utils.get_word_boundaries_in_line(line, word, 0)
+
+            eq(expected_word_start, word_start)
+            eq(expected_word_end, word_end)
+
+            word_start, word_end = utils.get_word_boundaries_in_line(line, word, 9)
+
+            eq(expected_word_start, word_start)
+            eq(expected_word_end, word_end)
+        end)
+
+        it('should return the word start and end positions (with position inside word)', function()
+            local word = 'abc'
+            local line = 'test ' .. word .. ' test'
+            local expected_word_start, expected_word_end = 6, 8
+
+            local word_start, word_end = utils.get_word_boundaries_in_line(line, word, 7)
+
+            eq(expected_word_start, word_start)
+            eq(expected_word_end, word_end)
+        end)
+
+        it('should return the word start and end positions of the closest word', function()
+            local word = 'abcdef'
+            local line = 'test ' .. word .. ' test ' .. word .. ' test'
+            local expected_word_start1, expected_word_end1 = 6, 11
+            local expected_word_start2, expected_word_end2 = 18, 23
+
+            local word_start, word_end = utils.get_word_boundaries_in_line(line, word, 9)
+
+            eq(expected_word_start1, word_start)
+            eq(expected_word_end1, word_end)
+
+            word_start, word_end = utils.get_word_boundaries_in_line(line, word, 21)
+
+            eq(expected_word_start2, word_start)
+            eq(expected_word_end2, word_end)
+        end)
+    end)
 end)


### PR DESCRIPTION
# Motivation

Refactor logic for `renamer._get_word_boundaries_in_line()` to give the closest word start and end positions relative to the received position in the line. Move function to `utils.get_word_boundaries_in_line()` and make tests for the new logic.

Closes: GH-43

## Proposed changes

- refactor `renamer._get_word_boundaries_in_line()` and move to `utils.get_word_boundaries_in_line()`

### Test plan

New test cases are defined in `lua/tests/utils_spec.lua`.
