### PR TITLE
fix(highlight): remove prefix highlight

### DIFF
--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -82,7 +82,7 @@ renamer.setup({opts})
                                     '╭', '╮', '╯', '╰' })
         {show_refs}     (boolean)   defines whether or not to highlight the
                                     current word references through the
-                                    built-in LSP
+                                    built-in LSP (default: true)
         {mappings}      (table)     the keymaps that should be available in
                                     the buffer, alongside their respective
                                     actions (default: see

--- a/plugin/renamer.vim
+++ b/plugin/renamer.vim
@@ -11,5 +11,4 @@ let g:loaded_renamer = 1
 hi default link RenamerNormal Normal
 hi default link RenamerBorder RenamerNormal
 hi default link RenamerTitle Identifier
-hi default link RenamerPrefix Identifier
 


### PR DESCRIPTION
# Motivation

Removes the highlight group which was not removed by GH-53.

## Proposed changes

- remove `RenamerPrefix` highlight group

### Test plan

N/A
