### PR TITLE
docs(neovim): add `show_refs` default

### DIFF
--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -82,7 +82,7 @@ renamer.setup({opts})
                                     '╭', '╮', '╯', '╰' })
         {show_refs}     (boolean)   defines whether or not to highlight the
                                     current word references through the
-                                    built-in LSP
+                                    built-in LSP (default: true)
         {mappings}      (table)     the keymaps that should be available in
                                     the buffer, alongside their respective
                                     actions (default: see


### PR DESCRIPTION
# Motivation

No default was put in `doc/renamer.txt` for `show_refs`.

## Proposed changes

- update `doc/renamer.txt`

### Test plan

Documentation changes do not require testing.
