### PR TITLE
fix!: popup draws correctly on screen edges

### DIFF
--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -83,13 +83,26 @@ function renamer.rename()
     local prompt_col_no, prompt_line_no = col - word_start + 1, 2
     local lines_from_win_end = vim.api.nvim_buf_line_count(0) - line
     local border_highlight = 'RenamerBorder'
+    local width, win_width = 0, vim.api.nvim_win_get_width(0)
+    if renamer.title then
+        width = #renamer.title + 4
+    end
 
-    if not renamer.border == true then
+    if not (renamer.border == true) then
         prompt_line_no = 1
         border_highlight = nil
     end
     if lines_from_win_end < prompt_line_no + 1 then
         prompt_line_no = -prompt_line_no
+    end
+    if #cword > width then
+        width = #cword
+    end
+    if word_start + width >= win_width then
+        prompt_col_no = prompt_col_no + width - win_width + word_start
+        if renamer.border == true then
+            prompt_col_no = prompt_col_no + 4
+        end
     end
 
     renamer._document_highlight()
@@ -102,7 +115,7 @@ function renamer.rename()
         borderchars = renamer.border_chars,
         highlight = 'RenamerNormal',
         borderhighlight = border_highlight,
-        width = #renamer.title + 4,
+        width = width,
         line = (prompt_line_no >= 0 and 'cursor+' or 'cursor') .. prompt_line_no,
         col = 'cursor-' .. prompt_col_no,
         posinvert = false,

--- a/lua/tests/renamer_layout_spec.lua
+++ b/lua/tests/renamer_layout_spec.lua
@@ -22,6 +22,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 local set_prompt_border_win_style = spy.on(renamer, '_set_prompt_border_win_style')
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -43,6 +44,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(cursor_line + expected_line_no + 1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -62,6 +64,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -81,6 +84,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(expected_col_no, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -101,6 +105,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(cursor_col, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -122,7 +127,32 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(word_start, 2)
+                local document_highlight = stub(renamer, '_document_highlight').returns()
+                stub(popup, 'create').returns(1, {})
+
+                local _, opts = renamer.rename()
+
+                eq(expected_col, opts.opts.col)
+                mock.revert(api_mock)
+                document_highlight.revert(document_highlight)
+            end)
+
+            it('should set the column position to have enough space to draw popup (cword at window end)', function()
+                local cursor_col = 10
+                local word_start = 8
+                local win_width = 11
+                -- no `word_start` as the formula would have `... - word_start ... + word_start`
+                local expected_col_no = cursor_col + 1 + #renamer.title + 4 - win_width + 4
+                local expected_col = 'cursor-' .. expected_col_no
+                local api_mock = mock(vim.api, true)
+                api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
+                api_mock.nvim_command.returns()
+                api_mock.nvim_buf_line_count.returns(1)
+                api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(win_width)
+                stub(utils, 'get_word_boundaries_in_line').returns(word_start, word_start + 5)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 
@@ -148,6 +178,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(cursor_line + expected_line_no + 1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -167,6 +198,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -186,6 +218,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(expected_col_no + 1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -206,6 +239,7 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(cursor_col + 1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -227,7 +261,32 @@ describe('renamer', function()
                 api_mock.nvim_command.returns()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
                 stub(utils, 'get_word_boundaries_in_line').returns(word_start, 2)
+                local document_highlight = stub(renamer, '_document_highlight').returns()
+                stub(popup, 'create').returns(1, {})
+
+                local _, opts = renamer.rename()
+
+                eq(expected_col, opts.opts.col)
+                mock.revert(api_mock)
+                document_highlight.revert(document_highlight)
+            end)
+
+            it('should set the column position to have enough space to draw popup (cword at window end)', function()
+                local cursor_col = 10
+                local word_start = 8
+                local win_width = 11
+                -- no `word_start` as the formula would have `... - word_start ... + word_start`
+                local expected_col_no = cursor_col + 1 + #renamer.title + 4 - win_width
+                local expected_col = 'cursor-' .. expected_col_no
+                local api_mock = mock(vim.api, true)
+                api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
+                api_mock.nvim_command.returns()
+                api_mock.nvim_buf_line_count.returns(1)
+                api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(win_width)
+                stub(utils, 'get_word_boundaries_in_line').returns(word_start, word_start + 5)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
 

--- a/lua/tests/renamer_rename_spec.lua
+++ b/lua/tests/renamer_rename_spec.lua
@@ -23,6 +23,7 @@ describe('renamer', function()
             api_mock.nvim_get_current_line.returns(expected_line)
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
             stub(vim.fn, 'expand').returns 'test'
             local get_word_boundaries_in_line = stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -41,6 +42,7 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
             spy.on(renamer, '_setup_window')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight_internal')
@@ -59,6 +61,7 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
             spy.on(renamer, '_setup_window')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             renamer.setup { show_refs = false }
@@ -78,6 +81,7 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
             local setup_window = spy.on(renamer, '_setup_window')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -96,6 +100,7 @@ describe('renamer', function()
             api_mock.nvim_command.returns()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
             local set_prompt_win_style = spy.on(renamer, '_set_prompt_win_style')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -114,6 +119,7 @@ describe('renamer', function()
             api_mock.nvim_command.returns()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
             local create_autocms = spy.on(renamer, '_create_autocmds')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -158,6 +164,7 @@ describe('renamer', function()
             api_mock.nvim_command.returns()
             api_mock.nvim_buf_line_count.returns(expected_line_no + 5)
             api_mock.nvim_get_mode.returns { mode = expected_opts.initial_mode }
+            api_mock.nvim_win_get_width.returns(100)
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
             stub(popup, 'create').returns(expected_buf_id, { border = expected_border_opts })
@@ -177,6 +184,7 @@ describe('renamer', function()
             api_mock.nvim_command.returns()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
             local mappings = require 'renamer.mappings'
             local register_bindings = spy.on(mappings, 'register_bindings')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)


### PR DESCRIPTION
# Motivation

Offset column position to the left, when the cursor is at the end of the window. This affects the popup with and without border.

BREAKING CHANGE: If the `cword` has a length greater than the `width`, set `width` to that of the `cword`. Add default width of 0, if `title` is not set.

Closes: GH-5

## Proposed changes

- update `rename()` to offset popup position if not enough space to draw it properly
- update `rename()` to not break when `title` is not set

### Test plan

Existing tests are updated to cover new functionality and two new test cases are added to `lua/tests/renamer_layout_spec.lua`.
