### PR TITLE
fix!: fallback to LSP rename if popup cannot be drawn

### DIFF
--- a/lua/tests/renamer_layout_spec.lua
+++ b/lua/tests/renamer_layout_spec.lua
@@ -14,7 +14,7 @@ describe('renamer', function()
         describe('popup width', function()
             it('should equal to cword length if title is too long', function()
                 renamer.setup { title = string.rep('a', 16) }
-                local cursor_col, word_start, win_width = 10, 8, 15
+                local cursor_col, word_start, win_width = 15, 13, 20
                 local cword = 'test'
                 local expected_width = #cword
                 local api_mock = mock(vim.api, true)
@@ -23,6 +23,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(win_width)
+                api_mock.nvim_win_get_height.returns(100)
                 local expand = stub(vim.fn, 'expand').returns(cword)
                 stub(utils, 'get_word_boundaries_in_line').returns(word_start, word_start + expected_width)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -38,7 +39,7 @@ describe('renamer', function()
 
             it('should equal to cword length if otherwise too short', function()
                 renamer.setup { title = 'a' }
-                local cursor_col, word_start, win_width = 10, 8, 15
+                local cursor_col, word_start, win_width = 15, 13, 20
                 local cword = 'testing'
                 local expected_width = #cword
                 local api_mock = mock(vim.api, true)
@@ -47,6 +48,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(win_width)
+                api_mock.nvim_win_get_height.returns(10)
                 local expand = stub(vim.fn, 'expand').returns(cword)
                 stub(utils, 'get_word_boundaries_in_line').returns(word_start, word_start + expected_width)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -73,6 +75,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 local set_prompt_border_win_style = spy.on(renamer, '_set_prompt_border_win_style')
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -95,6 +98,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(cursor_line + expected_line_no + 1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -115,6 +119,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -135,6 +140,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(expected_col_no, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -156,6 +162,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(cursor_col, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -178,6 +185,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(word_start, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -190,9 +198,9 @@ describe('renamer', function()
             end)
 
             it('should set the column position to have enough space to draw popup (cword at window end)', function()
-                local cursor_col = 10
-                local word_start = 8
-                local win_width = 11
+                local cursor_col = 19
+                local word_start = 17
+                local win_width = 20
                 -- no `word_start` as the formula would have `... - word_start ... + word_start`
                 local expected_col_no = cursor_col + 1 + #renamer.title + 4 - win_width + 4
                 local expected_col = 'cursor-' .. expected_col_no
@@ -202,6 +210,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(win_width)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(word_start, word_start + 5)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -229,6 +238,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(cursor_line + expected_line_no + 1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -249,6 +259,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -269,6 +280,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(expected_col_no + 1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -290,6 +302,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(cursor_col + 1, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -312,6 +325,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(word_start, 2)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})
@@ -324,9 +338,9 @@ describe('renamer', function()
             end)
 
             it('should set the column position to have enough space to draw popup (cword at window end)', function()
-                local cursor_col = 10
-                local word_start = 8
-                local win_width = 11
+                local cursor_col = 19
+                local word_start = 17
+                local win_width = 20
                 -- no `word_start` as the formula would have `... - word_start ... + word_start`
                 local expected_col_no = cursor_col + 1 + #renamer.title + 4 - win_width
                 local expected_col = 'cursor-' .. expected_col_no
@@ -336,6 +350,7 @@ describe('renamer', function()
                 api_mock.nvim_buf_line_count.returns(1)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(win_width)
+                api_mock.nvim_win_get_height.returns(10)
                 stub(utils, 'get_word_boundaries_in_line').returns(word_start, word_start + 5)
                 local document_highlight = stub(renamer, '_document_highlight').returns()
                 stub(popup, 'create').returns(1, {})

--- a/lua/tests/renamer_rename_spec.lua
+++ b/lua/tests/renamer_rename_spec.lua
@@ -15,6 +15,96 @@ describe('renamer', function()
             renamer.setup()
         end)
 
+        it('should fallback to `vim.lsp.buf.rename()` if width is too short (with border)', function()
+            local expected_cword = 'test'
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_cursor.returns()
+            api_mock.nvim_win_get_height.returns(15)
+            api_mock.nvim_win_get_width.returns(2)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
+            local expand = stub(vim.fn, 'expand').returns(expected_cword)
+            local rename = stub(renamer, '_nvim_lsp_rename').returns()
+            local document_highlight = stub(renamer, '_document_highlight').returns()
+            stub(popup, 'create').returns(1, {})
+
+            renamer.rename()
+
+            assert.spy(rename).called_at_least(1)
+            assert.spy(rename).called_at_most(1)
+            mock.revert(api_mock)
+            document_highlight.revert(document_highlight)
+            rename.revert(rename)
+            expand.revert(expand)
+        end)
+
+        it('should fallback to `vim.lsp.buf.rename()` if width is too short (without border)', function()
+            renamer.setup { border = false }
+            local expected_cword = 'test'
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_cursor.returns()
+            api_mock.nvim_win_get_height.returns(15)
+            api_mock.nvim_win_get_width.returns(1)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
+            local expand = stub(vim.fn, 'expand').returns(expected_cword)
+            local rename = stub(renamer, '_nvim_lsp_rename').returns()
+            local document_highlight = stub(renamer, '_document_highlight').returns()
+            stub(popup, 'create').returns(1, {})
+
+            renamer.rename()
+
+            assert.spy(rename).called_at_least(1)
+            assert.spy(rename).called_at_most(1)
+            mock.revert(api_mock)
+            document_highlight.revert(document_highlight)
+            rename.revert(rename)
+            expand.revert(expand)
+        end)
+
+        it('should fallback to `vim.lsp.buf.rename()` if height is too short (with border)', function()
+            local expected_cword = 'test'
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_cursor.returns()
+            api_mock.nvim_win_get_height.returns(3)
+            api_mock.nvim_win_get_width.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
+            local expand = stub(vim.fn, 'expand').returns(expected_cword)
+            local rename = stub(renamer, '_nvim_lsp_rename').returns()
+            local document_highlight = stub(renamer, '_document_highlight').returns()
+            stub(popup, 'create').returns(1, {})
+
+            renamer.rename()
+
+            assert.spy(rename).called_at_least(1)
+            assert.spy(rename).called_at_most(1)
+            mock.revert(api_mock)
+            document_highlight.revert(document_highlight)
+            rename.revert(rename)
+            expand.revert(expand)
+        end)
+
+        it('should fallback to `vim.lsp.buf.rename()` if height is too short (without border)', function()
+            renamer.setup { border = false }
+            local expected_cword = 'test'
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_cursor.returns()
+            api_mock.nvim_win_get_height.returns(3)
+            api_mock.nvim_win_get_width.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
+            local expand = stub(vim.fn, 'expand').returns(expected_cword)
+            local rename = stub(renamer, '_nvim_lsp_rename').returns()
+            local document_highlight = stub(renamer, '_document_highlight').returns()
+            stub(popup, 'create').returns(1, {})
+
+            renamer.rename()
+
+            assert.spy(rename).called_at_least(1)
+            assert.spy(rename).called_at_most(1)
+            mock.revert(api_mock)
+            document_highlight.revert(document_highlight)
+            rename.revert(rename)
+            expand.revert(expand)
+        end)
+
         it('should call `_get_word_boundaries_in_line`', function()
             local expected_cword, expected_line, expected_col = 'test', 1, 2
             local api_mock = mock(vim.api, true)
@@ -24,6 +114,8 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
             api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
             stub(vim.fn, 'expand').returns 'test'
             local get_word_boundaries_in_line = stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -43,6 +135,8 @@ describe('renamer', function()
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_get_mode.returns {}
             api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
             spy.on(renamer, '_setup_window')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight_internal')
@@ -62,6 +156,8 @@ describe('renamer', function()
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_get_mode.returns {}
             api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
             spy.on(renamer, '_setup_window')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             renamer.setup { show_refs = false }
@@ -82,6 +178,8 @@ describe('renamer', function()
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_get_mode.returns {}
             api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
             local setup_window = spy.on(renamer, '_setup_window')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -101,6 +199,8 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
             api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
             local set_prompt_win_style = spy.on(renamer, '_set_prompt_win_style')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -120,6 +220,8 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
             api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
             local create_autocms = spy.on(renamer, '_create_autocmds')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
@@ -168,6 +270,7 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(expected_line_no + 5)
             api_mock.nvim_get_mode.returns { mode = expected_opts.initial_mode }
             api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
             local document_highlight = stub(renamer, '_document_highlight').returns()
             stub(popup, 'create').returns(expected_buf_id, { border = expected_border_opts })
@@ -188,6 +291,8 @@ describe('renamer', function()
             api_mock.nvim_buf_line_count.returns(1)
             api_mock.nvim_get_mode.returns {}
             api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
             local mappings = require 'renamer.mappings'
             local register_bindings = spy.on(mappings, 'register_bindings')
             stub(utils, 'get_word_boundaries_in_line').returns(1, 2)


### PR DESCRIPTION
# Motivation

BREAKING CHANGE: Validate if the window height and width allow for the popup to be drawn, otherwise fallback to `vim.lsp.buf.rename()` and log an error.

Closes: GH-12

## Proposed changes

- update `rename()` to fallback to `vim.lsp.buf.rename()` if there is no space to draw the popup

### Test plan

Existing tests are updated to cover the new functionality and new test cases are also added in `lua/tests/renamer_rename_spec.lua`.

