### PR TITLE
feat(quickfix-list)!: add changes to qf list

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ require('renamer').setup {
     border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
     -- Whether or not to highlight the current word references through LSP
     show_refs = true,
+    -- Whether or not to add resulting changes to the quickfix list
+    with_qf_list = true,
     -- The keymaps available while in the `renamer` buffer. The example below
     -- overrides the default values, but you can add others as well.
     mappings = {

--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -49,6 +49,8 @@ renamer.setup({opts})
         border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
         -- Whether or not to highlight the current word references through LSP
         show_refs = true,
+        -- Whether or not to add resulting changes to the quickfix list
+        with_qf_list = true,
         -- The keymaps available while in the `renamer` buffer. The example below
         -- overrides the default values, but you can add others as well.
         mappings = {
@@ -89,6 +91,9 @@ renamer.setup({opts})
         {show_refs}     (boolean)   defines whether or not to highlight the
                                     current word references through the
                                     built-in LSP (default: true)
+        {with_qf_list}  (boolean)   defines whether or not to add the
+                                    resulting changes to the |quickfix| list
+                                    (default: true)
         {mappings}      (table)     the keymaps that should be available in
                                     the buffer, alongside their respective
                                     actions (default: see

--- a/lua/renamer/defaults.lua
+++ b/lua/renamer/defaults.lua
@@ -6,6 +6,7 @@ local mappings = require 'renamer.mappings'
 --- @field public border boolean
 --- @field public border_chars string[]
 --- @field public show_refs boolean
+--- @field public with_qf_list boolean
 --- @field public mappings string
 local defaults = {
     -- The popup title, shown if `border` is true
@@ -23,6 +24,8 @@ local defaults = {
     border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
     -- Whether or not to highlight the current word references through LSP
     show_refs = true,
+    -- Whether or not to add resulting changes to the quickfix list
+    with_qf_list = true,
     -- The keymaps available while in the `renamer` buffer. The example below
     -- overrides the default values, but you can add others as well.
     mappings = mappings.bindings,

--- a/lua/renamer/utils.lua
+++ b/lua/renamer/utils.lua
@@ -43,4 +43,40 @@ function utils.get_word_boundaries_in_line(line, word, line_pos)
     return closest_word_start, closest_word_end
 end
 
+function utils.set_qf_list(changes)
+    if changes then
+        local qf_list, i = {}, 0
+        for file, data in pairs(changes) do
+            local buf_id = -1
+            if vim.uri and vim.uri.uri_to_bufnr then
+                buf_id = vim.uri.uri_to_bufnr(file)
+            else
+                local file_path = string.gsub(file, 'file://', '')
+                buf_id = vim.fn.bufadd(file_path)
+            end
+            vim.fn.bufload(buf_id)
+            file = string.gsub(file, 'file://', '')
+
+            for _, change in ipairs(data) do
+                local row, col = change.range.start.line, change.range.start.character
+                if row == 0 then
+                    row = 1
+                end
+                i = i + 1
+                local line = vim.api.nvim_buf_get_lines(buf_id, row, row + 1, false)
+                qf_list[i] = {
+                    text = line and line[1],
+                    filename = file,
+                    lnum = row,
+                    col = col,
+                }
+            end
+        end
+
+        if qf_list and i > 0 then
+            vim.fn.setqflist(qf_list)
+        end
+    end
+end
+
 return utils

--- a/lua/tests/defaults_spec.lua
+++ b/lua/tests/defaults_spec.lua
@@ -14,6 +14,7 @@ describe('defaults', function()
             border = true,
             border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
             show_refs = true,
+            with_qf_list = true,
             mappings = mappings.bindings,
         }
 

--- a/lua/tests/renamer_setup_spec.lua
+++ b/lua/tests/renamer_setup_spec.lua
@@ -15,6 +15,7 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(defaults.show_refs, renamer.show_refs)
+            eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
@@ -32,6 +33,7 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(defaults.show_refs, renamer.show_refs)
+            eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
@@ -54,6 +56,7 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(defaults.show_refs, renamer.show_refs)
+            eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
@@ -71,6 +74,7 @@ describe('renamer', function()
             eq(opts.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(defaults.show_refs, renamer.show_refs)
+            eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
@@ -88,6 +92,7 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(opts.border_chars, renamer.border_chars)
             eq(defaults.show_refs, renamer.show_refs)
+            eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
@@ -95,7 +100,7 @@ describe('renamer', function()
         it('should use defaults where no options are passed ("show_refs" passed)', function()
             local mappings = require 'renamer.mappings'
             local opts = {
-                show_refs = true,
+                show_refs = false,
             }
 
             renamer.setup(opts)
@@ -105,6 +110,25 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(opts.show_refs, renamer.show_refs)
+            eq(defaults.with_qf_list, renamer.with_qf_list)
+            eq(defaults.mappings, mappings.bindings)
+            eq({}, renamer._buffers)
+        end)
+
+        it('should use defaults where no options are passed ("with_qf_list" passed)', function()
+            local mappings = require 'renamer.mappings'
+            local opts = {
+                with_qf_list = false,
+            }
+
+            renamer.setup(opts)
+
+            eq(defaults.title, renamer.title)
+            eq(defaults.padding, renamer.padding)
+            eq(defaults.border, renamer.border)
+            eq(defaults.border_chars, renamer.border_chars)
+            eq(defaults.show_refs, renamer.show_refs)
+            eq(opts.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
@@ -124,6 +148,7 @@ describe('renamer', function()
             eq(defaults.border, renamer.border)
             eq(defaults.border_chars, renamer.border_chars)
             eq(defaults.show_refs, renamer.show_refs)
+            eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(opts.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)
@@ -141,6 +166,7 @@ describe('renamer', function()
                 border = false,
                 border_chars = { '═', '║', '═', '║', '╔', '╗', '╝', '╚' },
                 show_refs = false,
+                with_qf_list = false,
                 mappings = {
                     ['<c-a>'] = 'test',
                 },
@@ -153,6 +179,7 @@ describe('renamer', function()
             eq(opts.border, renamer.border)
             eq(opts.border_chars, renamer.border_chars)
             eq(opts.show_refs, renamer.show_refs)
+            eq(opts.with_qf_list, renamer.with_qf_list)
             eq(opts.mappings, mappings.bindings)
             eq({}, renamer._buffers)
         end)


### PR DESCRIPTION
# Motivation

BREAKING CHANGE: Add rename changes to the quickfix list, conditioned by a new setup parameter. Update docs to describe the new parameter.

Closes: GH-69

## Proposed changes

- add `with_qf_list` parameter to `setup()` and `renamer.defaults`
- update docs
- 
### Test plan

Existing tests are updated with the new functionality and new test cases are added in `lua/tests/utils_spec.lua`.
