### PR TITLE
feat(rename)!: add option for empty popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,17 @@ current document, using `vim.lsp.buf.document_highlight()`. In order for it to
 be visible, the `LspReferenceText`, `LspReferenceRead` and `LspReferenceWrite`
 highlight groups need to be defined (see the
 [`vim.lsp.buf.document_highlight()`](https://neovim.io/doc/user/lsp.html#vim.lsp.buf.document_highlight())
- documentation for details).
+documentation for details).
+
+### Renamer rename structure
+
+```lua
+require('renamer').rename {
+    -- Defines whether or not the popup should contain the initial word or be
+    -- empty
+    empty = false,
+}
+```
 
 ## Default mappings
 
@@ -216,7 +226,8 @@ or no border:
 
 ![no-popup](media/renamer_no_popup.png "No popup")
 
-Thanks @sdushantha for suggesting this (and providing the screenshot)!
+Thanks [@sdushantha](https://github.com/sdushantha) for suggesting this (and
+providing the screenshot)!
 
 ## Contributing
 

--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -70,7 +70,7 @@ renamer.setup({opts})
 
 
     Parameters: ~
-        {opts} (table)  options to pass to the setup function
+        {opts}          (table)     options to pass to the setup function
 
     Fields: ~
         {title}         (string)    title of the popup, shown on the top border
@@ -112,17 +112,33 @@ renamer.setup({opts})
 ===============================================================================
                                                              *renamer.rename()*
 
-renamer.rename()
-   Function that renames the word under the cursor, using Neovim's built in
-   LSP feature (see |vim.lsp.buf.rename()|). Creates a popup next to the
-   cursor, starting at the beginning of the word.
+renamer.rename({opts})
+    Function that renames the word under the cursor, using Neovim's built in
+    LSP features (see |vim.lsp.buf_request()|). Creates a popup next to the
+    cursor, starting at the beginning of the word.
 
-   The popup is drawn below the current line, if there is enough space,
-   otherwise on the one above it.
+    The popup is drawn below the current line, if there is enough space,
+    otherwise on the one above it.
 
-   Usage:
-   >
-   require('renamer').rename()
+    Usage:
+    >
+    require('renamer').rename()
+<
+    To rename without having the existing name in the popup, use the following:
+    >
+    require('renamer').rename {
+        empty = true,
+    }
+<
+
+
+    Parameters: ~
+        {opts}      (table)     options to pass to the rename function
+
+    Fields: ~
+        {empty}     (boolean)   defines whether or not the popup should
+                                contain the initial word or be empty
+                                (default: true)
 
 
 

--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -84,7 +84,7 @@ function renamer.setup(opts)
 end
 
 --- Function that renames the word under the cursor, using Neovim's built in
---- LSP feature (`vim.lsp.buf.rename()`). Creates a popup next to the cursor,
+--- LSP features (`vim.lsp.buf_request()`). Creates a popup next to the cursor,
 --- starting at the beginning of the word.
 ---
 --- The popup is drawn below the current line, if there is enough space,
@@ -94,9 +94,19 @@ end
 --- <code>
 --- require('renamer').rename()
 --- </code>
+---
+--- To rename without having the existing name in the popup, use the following:
+---
+--- <code>
+--- require('renamer').rename {
+---     empty = true,
+--- }
+--- </code>
+--- @param opts table Rename specific options (ie: `empty`).
 --- @return integer prompt_window_id
 --- @return table prompt_window_opts @Keys: opts, border_opts
-function renamer.rename()
+function renamer.rename(opts)
+    opts = opts or { empty = false }
     local cword = vim.fn.expand '<cword>'
     local win_height = vim.api.nvim_win_get_height(0)
     local win_width = vim.api.nvim_win_get_width(0)
@@ -152,7 +162,12 @@ function renamer.rename()
         renamer._clear_references()
         return
     end
-    local prompt_win_id, prompt_opts = popup.create(cword, popup_opts)
+
+    local popup_content = cword
+    if opts.empty == true then
+        popup_content = ''
+    end
+    local prompt_win_id, prompt_opts = popup.create(popup_content, popup_opts)
 
     renamer._buffers[prompt_win_id] = {
         opts = popup_opts,

--- a/lua/tests/renamer_rename_spec.lua
+++ b/lua/tests/renamer_rename_spec.lua
@@ -452,5 +452,84 @@ describe('renamer', function()
             mock.revert(api_mock)
             document_highlight.revert(document_highlight)
         end)
+
+        it('should default to "empty" being `false` if not specified', function()
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_cursor.returns { 1, 2 }
+            api_mock.nvim_command.returns()
+            api_mock.nvim_buf_line_count.returns(1)
+            api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
+            local expected_word = 'test'
+            local expand = stub(vim.fn, 'expand').returns(expected_word)
+            local document_highlight = stub(renamer, '_document_highlight')
+            local word = ''
+            stub(popup, 'create').invokes(function(...)
+                word, _ = ...
+                return 1, {}
+            end)
+
+            renamer.rename()
+
+            eq(expected_word, word)
+            mock.revert(api_mock)
+            document_highlight.revert(document_highlight)
+            expand.revert(expand)
+        end)
+
+        it('should default to "empty" being `false` if nil', function()
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_cursor.returns { 1, 2 }
+            api_mock.nvim_command.returns()
+            api_mock.nvim_buf_line_count.returns(1)
+            api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
+            local expected_word = 'test'
+            local document_highlight = stub(renamer, '_document_highlight')
+            local word = ''
+            stub(popup, 'create').invokes(function(...)
+                word, _ = ...
+                return 1, {}
+            end)
+
+            renamer.rename {}
+
+            eq(expected_word, word)
+            mock.revert(api_mock)
+            document_highlight.revert(document_highlight)
+        end)
+
+        it('should be empty if "empty" is `true`', function()
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_cursor.returns { 1, 2 }
+            api_mock.nvim_command.returns()
+            api_mock.nvim_buf_line_count.returns(1)
+            api_mock.nvim_get_mode.returns {}
+            api_mock.nvim_win_get_width.returns(100)
+            api_mock.nvim_win_get_height.returns(10)
+            api_mock.nvim_get_mode.returns { mode = 'n' }
+            stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
+            local document_highlight = stub(renamer, '_document_highlight')
+            local expected_word = ''
+            local word = 'test'
+            stub(popup, 'create').invokes(function(...)
+                word, _ = ...
+                return 1, {}
+            end)
+
+            renamer.rename {
+                empty = true,
+            }
+
+            eq(expected_word, word)
+            mock.revert(api_mock)
+            document_highlight.revert(document_highlight)
+        end)
     end)
 end)


### PR DESCRIPTION
# Motivation

BREAKING CHANGE: Add options to `rename()` to allow for the popup to be empty or contain the initial word.

Closes: GH-71

## Proposed changes

- add options to `rename()`
- update docs

### Test plan

Existing tests are updated and new test cases are added to `lua/tests/renamer_rename_spec.lua`.