### PR TITLE
fix(rename): cursor placement at word end

### DIFF
--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -173,10 +173,10 @@ function renamer.rename(opts)
         opts = popup_opts,
         border_opts = prompt_opts.border,
     }
-    renamer._set_cursor_to_popup_end()
     log.fmt_info('Created "plenary" popup, with options: %s', vim.inspect(renamer._buffers[prompt_win_id]))
 
     renamer._setup_window(prompt_win_id)
+    renamer._set_cursor_to_popup_end()
     log.trace 'Finished setting up the popup.'
     renamer._set_prompt_win_style(prompt_win_id)
     log.trace 'Finished styling the popup.'


### PR DESCRIPTION
# Motivation

Move `_set_cursor_to_popup_end()` call after the `_setup_window()` call, in order to properly place the cursor at the word end, as a20b471 did not set it properly.

Closes: GH-73

## Proposed changes

- move `_set_cursor_to_popup_end()` call after the `_setup_window()` call

### Test plan

Existing tests cover the new behaviour.
