### PR TITLE
fix(qflist): first line in file was not set correctly

### DIFF
--- a/lua/renamer/utils.lua
+++ b/lua/renamer/utils.lua
@@ -59,9 +59,6 @@ function utils.set_qf_list(changes)
 
             for _, change in ipairs(data) do
                 local row, col = change.range.start.line, change.range.start.character
-                if row == 0 then
-                    row = 1
-                end
                 i = i + 1
                 local line = vim.api.nvim_buf_get_lines(buf_id, row, row + 1, false)
                 qf_list[i] = {


### PR DESCRIPTION
# Motivation

Remove unnecessary modification of first row, in `utils.set_qf_list()`, in order to properly populate the list.

Closes: GH-79

## Proposed changes

- remove row reassigning for the first row of a file

### Test plan

Existing test are update to validate the new functionality.
