### PR TITLE
feat!: add custom handler for successful renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ require('renamer').setup {
         ['<c-u>'] = mappings_utils.undo,
         ['<c-r>'] = mappings_utils.redo,
     },
+    -- Custom handler to be run after successfully renaming the word. Receives
+    -- the LSP 'textDocument/rename' raw response as its parameter.
+    handler = nil,
 }
 ```
 

--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -65,6 +65,9 @@ renamer.setup({opts})
             ['<c-u>'] = mappings_utils.undo,
             ['<c-r>'] = mappings_utils.redo,
         },
+        -- Custom handler to be run after successfully renaming the word. Receives
+        -- the LSP 'textDocument/rename' raw response as its parameter.
+        handler = nil,
     }
 <
 
@@ -105,6 +108,10 @@ renamer.setup({opts})
                                     the buffer, alongside their respective
                                     actions (default: see
                                     |lua/renamer/mappings/init.lua|)
+        {handler}       (function)  custom handler to be run after
+                                    successfully renaming the word; receives
+                                    the raw LSP `textDocument/rename` response
+                                    as its parameter (default: nil)
 
 
 

--- a/lua/renamer/defaults.lua
+++ b/lua/renamer/defaults.lua
@@ -9,6 +9,7 @@ local mappings = require 'renamer.mappings'
 --- @field public with_qf_list boolean
 --- @field public with_popup boolean
 --- @field public mappings string
+--- @field public handler function
 local defaults = {
     -- The popup title, shown if `border` is true
     title = 'Rename',
@@ -32,7 +33,10 @@ local defaults = {
     with_popup = true,
     -- The keymaps available while in the `renamer` buffer. The example below
     -- overrides the default values, but you can add others as well.
-    mappings = mappings.bindings,
+    mappings = mappings.default_bindings,
+    -- Custom handler to be run after successfully renaming the word. Receives
+    -- the LSP 'textDocument/rename' raw response as its parameter.
+    handler = nil,
 }
 
 return defaults

--- a/lua/renamer/mappings/init.lua
+++ b/lua/renamer/mappings/init.lua
@@ -1,10 +1,10 @@
 local utils = require 'renamer.mappings.utils'
 
 --- @class Mappings
---- @field public bindings table
+--- @field public default_bindings table
 --- @field public keymap_opts table
 local mappings = {
-    bindings = {
+    default_bindings = {
         ['<c-i>'] = utils.set_cursor_to_start,
         ['<c-a>'] = utils.set_cursor_to_end,
         ['<c-e>'] = utils.set_cursor_to_word_end,

--- a/lua/tests/defaults_spec.lua
+++ b/lua/tests/defaults_spec.lua
@@ -16,7 +16,8 @@ describe('defaults', function()
             show_refs = true,
             with_qf_list = true,
             with_popup = true,
-            mappings = mappings.bindings,
+            mappings = mappings.default_bindings,
+            handler = nil,
         }
 
         local defaults = require 'renamer.defaults'

--- a/lua/tests/mappings/mappings_defaults_spec.lua
+++ b/lua/tests/mappings/mappings_defaults_spec.lua
@@ -4,7 +4,7 @@ local eq = assert.are.same
 
 describe('mappings', function()
     it('should have actions initialized for all `bindings`', function()
-        local bindings = mappings.bindings
+        local bindings = mappings.default_bindings
 
         for key, value in pairs(bindings) do
             assert(value, string.format('No action mapped to "%s".', key))

--- a/lua/tests/mappings/mappings_exec_keymap_action_spec.lua
+++ b/lua/tests/mappings/mappings_exec_keymap_action_spec.lua
@@ -8,8 +8,9 @@ describe('mappings', function()
     describe('exec_keymap_action', function()
         it('should not execute if `keymap` is nil', function()
             local binding = '<c-a>'
-            local initial_action = mappings.bindings[binding]
+            local initial_action = mappings.default_bindings[binding]
             local was_called = false
+            mappings.bindings = {}
             mappings.bindings[binding] = function()
                 was_called = true
             end
@@ -22,8 +23,9 @@ describe('mappings', function()
 
         it('should execute the action associated with a valid binding', function()
             local binding = '<c-a>'
-            local initial_action = mappings.bindings[binding]
+            local initial_action = mappings.default_bindings[binding]
             local was_called = false
+            mappings.bindings = {}
             mappings.bindings[binding] = function()
                 was_called = true
             end

--- a/lua/tests/mappings/mappings_register_bindings_spec.lua
+++ b/lua/tests/mappings/mappings_register_bindings_spec.lua
@@ -15,31 +15,28 @@ describe('mappings', function()
         it('should not set keymaps if `bindings` is nil', function()
             local buf_id = 1
             local set_keymap = stub(vim.api, 'nvim_buf_set_keymap')
-            local initial_bindings = mappings.bindings
             mappings.bindings = nil
 
             mappings.register_bindings(buf_id)
 
             assert.spy(set_keymap).called_less_than(1)
-            mappings.bindings = initial_bindings
         end)
 
         it('should not set keymaps if `bindings` is empty', function()
             local buf_id = 1
             local set_keymap = stub(vim.api, 'nvim_buf_set_keymap')
-            local initial_bindings = mappings.bindings
             mappings.bindings = {}
 
             mappings.register_bindings(buf_id)
 
             assert.spy(set_keymap).called_less_than(1)
-            mappings.bindings = initial_bindings
         end)
 
         it('should set `bindings` as keymaps for the received buffer', function()
             local buf_id = 1
             local set_keymap = stub(vim.api, 'nvim_buf_set_keymap')
-            local bindings = mappings.bindings
+            local bindings = mappings.default_bindings
+            mappings.bindings = bindings
 
             mappings.register_bindings(buf_id)
 

--- a/lua/tests/renamer_setup_spec.lua
+++ b/lua/tests/renamer_setup_spec.lua
@@ -17,6 +17,7 @@ describe('renamer', function()
             eq(defaults.show_refs, renamer.show_refs)
             eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
+            eq(defaults.handler, renamer.handler)
             eq({}, renamer._buffers)
         end)
 
@@ -35,6 +36,7 @@ describe('renamer', function()
             eq(defaults.show_refs, renamer.show_refs)
             eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
+            eq(defaults.handler, renamer.handler)
             eq({}, renamer._buffers)
         end)
 
@@ -58,6 +60,7 @@ describe('renamer', function()
             eq(defaults.show_refs, renamer.show_refs)
             eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
+            eq(defaults.handler, renamer.handler)
             eq({}, renamer._buffers)
         end)
 
@@ -76,6 +79,7 @@ describe('renamer', function()
             eq(defaults.show_refs, renamer.show_refs)
             eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
+            eq(defaults.handler, renamer.handler)
             eq({}, renamer._buffers)
         end)
 
@@ -94,6 +98,7 @@ describe('renamer', function()
             eq(defaults.show_refs, renamer.show_refs)
             eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
+            eq(defaults.handler, renamer.handler)
             eq({}, renamer._buffers)
         end)
 
@@ -112,6 +117,7 @@ describe('renamer', function()
             eq(opts.show_refs, renamer.show_refs)
             eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
+            eq(defaults.handler, renamer.handler)
             eq({}, renamer._buffers)
         end)
 
@@ -130,6 +136,7 @@ describe('renamer', function()
             eq(defaults.show_refs, renamer.show_refs)
             eq(opts.with_qf_list, renamer.with_qf_list)
             eq(defaults.mappings, mappings.bindings)
+            eq(defaults.handler, renamer.handler)
             eq({}, renamer._buffers)
         end)
 
@@ -150,6 +157,28 @@ describe('renamer', function()
             eq(defaults.show_refs, renamer.show_refs)
             eq(defaults.with_qf_list, renamer.with_qf_list)
             eq(opts.mappings, mappings.bindings)
+            eq(defaults.handler, renamer.handler)
+            eq({}, renamer._buffers)
+        end)
+
+        it('should use defaults where no options are passed ("handler" passed)', function()
+            local mappings = require 'renamer.mappings'
+            local opts = {
+                handler = function(resp)
+                    print(resp)
+                end,
+            }
+
+            renamer.setup(opts)
+
+            eq(defaults.title, renamer.title)
+            eq(defaults.padding, renamer.padding)
+            eq(defaults.border, renamer.border)
+            eq(defaults.border_chars, renamer.border_chars)
+            eq(defaults.show_refs, renamer.show_refs)
+            eq(defaults.with_qf_list, renamer.with_qf_list)
+            eq(defaults.mappings, mappings.bindings)
+            eq(opts.handler, renamer.handler)
             eq({}, renamer._buffers)
         end)
 
@@ -171,6 +200,9 @@ describe('renamer', function()
                 mappings = {
                     ['<c-a>'] = 'test',
                 },
+                handler = function(resp)
+                    print(resp)
+                end,
             }
 
             renamer.setup(opts)
@@ -183,6 +215,7 @@ describe('renamer', function()
             eq(opts.with_qf_list, renamer.with_qf_list)
             eq(opts.with_popup, renamer.with_popup)
             eq(opts.mappings, mappings.bindings)
+            eq(opts.handler, renamer.handler)
             eq({}, renamer._buffers)
         end)
     end)


### PR DESCRIPTION
# Motivation

This PR adds two new changes, related to GH-84:

---
BREAKING CHANGE: Add a new field, `handler`, representing a function to be called after successful renames, with the LSP `textDocument/rename` raw response.

Closes: GH-84

---
BREAKING CHANGE: TODO integrate `nvim-notify`

## Proposed changes

- add `handler` field to be called with the LSP raw response on successful renames
- update docs

### Test plan

Existing tests are updated to validate the new functionalities and new test cases are added for each new behaviour.
