### PR TITLE
docs: fix Lua in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ require('renamer').setup {
         left = 0,
         bottom = 0,
         right = 0,
-    }
+    },
     -- Whether or not to shown a border around the popup
     border = true,
     -- The characters which make up the border

--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -42,7 +42,7 @@ renamer.setup({opts})
             left = 0,
             bottom = 0,
             right = 0,
-        }
+        },
         -- Whether or not to shown a border around the popup
         border = true,
         -- The characters which make up the border

--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -35,7 +35,7 @@ local renamer = {}
 ---         left = 0,
 ---         bottom = 0,
 ---         right = 0,
----     }
+---     },
 ---     -- Whether or not to shown a border around the popup
 ---     border = true,
 ---     -- The characters which make up the border


### PR DESCRIPTION
# Motivation

Add missing `,` in various Lua snippets found in docs.

## Proposed changes

- update docs

### Test plan

No tests needed for documentation changes.