### PR TITLE
fix(rename): handle `documentChanges` LSP response

### DIFF
--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -371,6 +371,15 @@ function renamer._lsp_rename(word, pos)
                 log.warn 'LSP response is nil.'
                 return
             end
+            local changes = resp.changes
+            if resp.documentChanges then
+                changes = {}
+                for _, change in ipairs(resp.documentChanges) do
+                    changes[change.textDocument.uri] = {
+                        change.edits,
+                    }
+                end
+            end
 
             lsp_utils.apply_workspace_edit(resp)
 


### PR DESCRIPTION
# Motivation

Handle LSP rename responses containing `documentChanges`, as some servers only provide this field and for those that provide it as well as `changes`, `documentChanges` should be prefered, as indicated by the [LSP documentation][lsp-rename-docs].

Refs: GH-84

[lsp-rename-docs]:
https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/

## Proposed changes

- handle `documentChanges` in LSP response, in `renamer._lsp_rename()`

### Test plan

Existing tests cover the new behaviour.