### PR TITLE
fix: responses with `documentChanges` set qflist properly

### DIFF
--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -375,16 +375,14 @@ function renamer._lsp_rename(word, pos)
             if resp.documentChanges then
                 changes = {}
                 for _, change in ipairs(resp.documentChanges) do
-                    changes[change.textDocument.uri] = {
-                        change.edits,
-                    }
+                    changes[change.textDocument.uri] = change.edits
                 end
             end
 
             lsp_utils.apply_workspace_edit(resp)
 
             if renamer.with_qf_list then
-                utils.set_qf_list(resp.changes)
+                utils.set_qf_list(changes)
             end
             if pos then
                 local col = pos.word_start + #word - 1

--- a/lua/renamer/utils.lua
+++ b/lua/renamer/utils.lua
@@ -64,8 +64,8 @@ function utils.set_qf_list(changes)
                 qf_list[i] = {
                     text = line and line[1],
                     filename = file,
-                    lnum = row,
-                    col = col,
+                    lnum = row + 1,
+                    col = col + 1,
                 }
             end
         end


### PR DESCRIPTION
# Motivation

The fix for GH-84 introduced a bug for LSP servers that provide the `documentChanges` field, making the quickfix list not be set.

References: GH-84

# Proposed changes

- send the proper field in the `set_qf_list` call in `on_submit()`
- properly set changes for responses containing `documentChanges`

## Test plan

Existing tests cover the functionality.