### PR TITLE
tests(qf-list): fix failing tests

### DIFF
--- a/lua/tests/utils_spec.lua
+++ b/lua/tests/utils_spec.lua
@@ -170,8 +170,8 @@ describe('utils', function()
                     expected_qf_list[1] = {
                         text = 'test',
                         filename = string.gsub(file, 'file://', ''),
-                        lnum = row,
-                        col = col,
+                        lnum = row + 1,
+                        col = col + 1,
                     }
                 end
             end


### PR DESCRIPTION
# Motivation

Changes made by 645e7bd lead to one test case for `set_qf_list()` to fail. This commit fixes the broken test to match the new functionality.

References: GH-90

## Proposed changes

- update the failing test case in `lua/tests/utils_spec.lua`

### Test plan

Since this PR fixes tests, if the CI passing covers the changes.
