### PR TITLE
fix: popup showing when no LSP client attached

### DIFF
--- a/lua/renamer/constants.lua
+++ b/lua/renamer/constants.lua
@@ -56,6 +56,7 @@ local strings = {
     checking_setup_called = 'Chechking whether setup was made...',
     setup_not_called = '"renamer.setup()" not called. Please make sure setup is done before using the plugin.',
     invalid_type_err_template = 'Invalid type for "%s". Expected "%s", but found "%s".',
+    no_lsp_client_found_err = 'No LSP client found for the current file, but "renamer" requires one to work.',
 }
 
 return {

--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -115,6 +115,12 @@ end
 --- @return table prompt_window_opts @Keys: opts, border_opts
 function renamer.rename(opts)
     opts = opts or { empty = false }
+
+    local lsp_clients = vim.lsp.buf_get_clients(0)
+    if lsp_clients == nil or #lsp_clients < 1 then
+        log.error(strings.no_lsp_client_found_err)
+    end
+
     local cword = vim.fn.expand(strings.cword_keyword)
     local win_height = vim.api.nvim_win_get_height(0)
     local win_width = vim.api.nvim_win_get_width(0)
@@ -368,7 +374,7 @@ function renamer._lsp_rename(word, pos)
                 log.error(err)
                 return
             end
-            if not resp then
+            if resp == nil then
                 log.warn(strings.nil_lsp_response_err)
                 return
             end
@@ -380,7 +386,7 @@ function renamer._lsp_rename(word, pos)
                 end
             end
 
-            lsp_utils.apply_workspace_edit(resp)
+            renamer._apply_workspace_edit(resp)
 
             if renamer.with_qf_list then
                 utils.set_qf_list(changes)
@@ -455,6 +461,10 @@ end
 -- Since there is no way to mock `vim.lsp.buf_request`, this function is used as a replacement
 function renamer._buf_request(buf_id, method, params, handler)
     vim.lsp.buf_request(buf_id, method, params, handler)
+end
+
+function renamer._apply_workspace_edit(resp)
+    lsp_utils.apply_workspace_edit(resp)
 end
 
 return renamer

--- a/lua/tests/renamer_close_spec.lua
+++ b/lua/tests/renamer_close_spec.lua
@@ -1,5 +1,6 @@
 local strings = require('renamer.constants').strings
 local renamer = require 'renamer'
+local utils = require 'renamer.utils'
 
 local mock = require 'luassert.mock'
 local stub = require 'luassert.stub'
@@ -142,32 +143,192 @@ describe('renamer', function()
             lsp_rename.revert(lsp_rename)
         end)
 
-        it('should set cursor after the end of the new word', function()
+        it('should not apply changes if error is received', function()
             local expected_win_id, expected_buf_id = 123, 321
             local expected_content = 'test'
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_buf.returns(expected_buf_id)
             api_mock.nvim_buf_get_lines.returns { expected_content }
             api_mock.nvim_command.returns()
-            api_mock.nvim_win_set_cursor.returns()
             local on_close = stub(renamer, 'on_close').returns()
-            local expected_pos = { word_start = 1, line = 1, col = 1 }
-            local expected_params = {}
-            local make_params = stub(renamer, '_make_position_params').returns(expected_params)
-            local buf_request = stub(renamer, '_buf_request').invokes(function()
-                api_mock.nvim_win_set_cursor(0, { expected_pos.line, expected_pos.col })
+            local buf_request = stub(renamer, '_buf_request').invokes(function(_, _, _, handler)
+                handler({}, nil)
             end)
-            renamer._buffers[expected_win_id] = { opts = { initial_pos = expected_pos } }
+            local expected_pos = { word_start = 1, line = 1, col = 1 }
+            renamer._buffers[expected_win_id] = { opts = { initial_word = 'test', initial_pos = expected_pos } }
+            local apply_changes = stub(renamer, '_apply_workspace_edit')
+            local make_params = stub(renamer, '_make_position_params').returns {}
 
             renamer.on_submit(expected_win_id)
 
-            assert.spy(buf_request).was_called()
+            assert.spy(apply_changes).called_less_than(1)
             assert.spy(on_close).was_called_with(expected_win_id, false)
             assert.spy(api_mock.nvim_win_get_buf).was_called_with(expected_win_id)
             assert.spy(api_mock.nvim_buf_get_lines).was_called_with(expected_buf_id, -2, -1, false)
             mock.revert(api_mock)
-            buf_request.revert(buf_request)
             on_close.revert(on_close)
+            buf_request.revert(buf_request)
+            apply_changes.revert(apply_changes)
+            make_params.revert(make_params)
+        end)
+
+        it('should not apply changes if no response is received', function()
+            local expected_win_id, expected_buf_id = 123, 321
+            local expected_content = 'test'
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_buf.returns(expected_buf_id)
+            api_mock.nvim_buf_get_lines.returns { expected_content }
+            api_mock.nvim_command.returns()
+            local on_close = stub(renamer, 'on_close').returns()
+            local buf_request = stub(renamer, '_buf_request').invokes(function(_, _, _, handler)
+                handler(nil, nil)
+            end)
+            local expected_pos = { word_start = 1, line = 1, col = 1 }
+            renamer._buffers[expected_win_id] = { opts = { initial_word = 'test', initial_pos = expected_pos } }
+            local apply_changes = stub(renamer, '_apply_workspace_edit')
+            local make_params = stub(renamer, '_make_position_params').returns {}
+
+            renamer.on_submit(expected_win_id)
+
+            assert.spy(apply_changes).called_less_than(1)
+            assert.spy(on_close).was_called_with(expected_win_id, false)
+            assert.spy(api_mock.nvim_win_get_buf).was_called_with(expected_win_id)
+            assert.spy(api_mock.nvim_buf_get_lines).was_called_with(expected_buf_id, -2, -1, false)
+            mock.revert(api_mock)
+            on_close.revert(on_close)
+            buf_request.revert(buf_request)
+            apply_changes.revert(apply_changes)
+            make_params.revert(make_params)
+        end)
+
+        it('should apply changes if no error is received', function()
+            renamer.setup { with_qf_list = false }
+            local expected_win_id, expected_buf_id = 123, 321
+            local expected_content = 'test'
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_buf.returns(expected_buf_id)
+            api_mock.nvim_buf_get_lines.returns { expected_content }
+            api_mock.nvim_command.returns()
+            api_mock.nvim_get_mode.returns(strings.insert_mode_short_string)
+            local on_close = stub(renamer, 'on_close').returns()
+            local buf_request = stub(renamer, '_buf_request').invokes(function(_, _, _, handler)
+                handler(nil, {})
+            end)
+            local expected_pos = { word_start = 1, line = 1, col = 1 }
+            renamer._buffers[expected_win_id] = { opts = { initial_word = 'test', initial_pos = expected_pos } }
+            local apply_changes = stub(renamer, '_apply_workspace_edit')
+            local make_params = stub(renamer, '_make_position_params').returns {}
+
+            renamer.on_submit(expected_win_id)
+
+            assert.spy(apply_changes).was_called()
+            assert.spy(on_close).was_called_with(expected_win_id, false)
+            assert.spy(api_mock.nvim_win_get_buf).was_called_with(expected_win_id)
+            assert.spy(api_mock.nvim_buf_get_lines).was_called_with(expected_buf_id, -2, -1, false)
+            mock.revert(api_mock)
+            on_close.revert(on_close)
+            buf_request.revert(buf_request)
+            apply_changes.revert(apply_changes)
+            make_params.revert(make_params)
+        end)
+
+        it('should call the custom handler if it is set', function()
+            local custom_handler_called = false
+            renamer.setup {
+                with_qf_list = false,
+                handler = function()
+                    custom_handler_called = true
+                end,
+            }
+            local expected_win_id, expected_buf_id = 123, 321
+            local expected_content = 'test'
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_buf.returns(expected_buf_id)
+            api_mock.nvim_buf_get_lines.returns { expected_content }
+            api_mock.nvim_command.returns()
+            api_mock.nvim_get_mode.returns(strings.insert_mode_short_string)
+            local on_close = stub(renamer, 'on_close').returns()
+            local buf_request = stub(renamer, '_buf_request').invokes(function(_, _, _, handler)
+                handler(nil, {})
+            end)
+            local expected_pos = { word_start = 1, line = 1, col = 1 }
+            renamer._buffers[expected_win_id] = { opts = { initial_word = 'test', initial_pos = expected_pos } }
+            local apply_changes = stub(renamer, '_apply_workspace_edit')
+            local make_params = stub(renamer, '_make_position_params').returns {}
+
+            renamer.on_submit(expected_win_id)
+
+            eq(true, custom_handler_called)
+            assert.spy(on_close).was_called_with(expected_win_id, false)
+            assert.spy(api_mock.nvim_win_get_buf).was_called_with(expected_win_id)
+            assert.spy(api_mock.nvim_buf_get_lines).was_called_with(expected_buf_id, -2, -1, false)
+            mock.revert(api_mock)
+            on_close.revert(on_close)
+            buf_request.revert(buf_request)
+            apply_changes.revert(apply_changes)
+            make_params.revert(make_params)
+        end)
+
+        it('should set qf list if the option is turned on', function()
+            local expected_win_id, expected_buf_id = 123, 321
+            local expected_content = 'test'
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_buf.returns(expected_buf_id)
+            api_mock.nvim_buf_get_lines.returns { expected_content }
+            api_mock.nvim_command.returns()
+            local on_close = stub(renamer, 'on_close').returns()
+            local buf_request = stub(renamer, '_buf_request').invokes(function(_, _, _, handler)
+                handler({}, nil)
+            end)
+            local expected_pos = { word_start = 1, line = 1, col = 1 }
+            renamer._buffers[expected_win_id] = { opts = { initial_word = 'test', initial_pos = expected_pos } }
+            local apply_changes = stub(renamer, '_apply_workspace_edit')
+            local set_qf_list = stub(utils, 'set_qf_list')
+            local make_params = stub(renamer, '_make_position_params').returns {}
+
+            renamer.on_submit(expected_win_id)
+
+            assert.spy(apply_changes).called_less_than(1)
+            assert.spy(on_close).was_called_with(expected_win_id, false)
+            assert.spy(api_mock.nvim_win_get_buf).was_called_with(expected_win_id)
+            assert.spy(api_mock.nvim_buf_get_lines).was_called_with(expected_buf_id, -2, -1, false)
+            mock.revert(api_mock)
+            on_close.revert(on_close)
+            buf_request.revert(buf_request)
+            apply_changes.revert(apply_changes)
+            make_params.revert(make_params)
+            set_qf_list.revert(set_qf_list)
+        end)
+
+        it('should set cursor after the end of the new word', function()
+            renamer.setup { with_qf_list = false }
+            local expected_win_id, expected_buf_id = 123, 321
+            local expected_content = 'test'
+            local api_mock = mock(vim.api, true)
+            api_mock.nvim_win_get_buf.returns(expected_buf_id)
+            api_mock.nvim_buf_get_lines.returns { expected_content }
+            api_mock.nvim_command.returns()
+            api_mock.nvim_get_mode.returns(strings.insert_mode_short_string)
+            local on_close = stub(renamer, 'on_close').returns()
+            local buf_request = stub(renamer, '_buf_request').invokes(function(_, _, _, handler)
+                handler(nil, {})
+            end)
+            local expected_pos = { word_start = 1, line = 1, col = 1 }
+            local expected_col = expected_pos.word_start + #expected_content - 1
+            renamer._buffers[expected_win_id] = { opts = { initial_word = 'test', initial_pos = expected_pos } }
+            local apply_changes = stub(renamer, '_apply_workspace_edit')
+            local make_params = stub(renamer, '_make_position_params').returns {}
+
+            renamer.on_submit(expected_win_id)
+
+            assert.spy(api_mock.nvim_win_set_cursor).was_called_with(0, { expected_pos.line, expected_col })
+            assert.spy(on_close).was_called_with(expected_win_id, false)
+            assert.spy(api_mock.nvim_win_get_buf).was_called_with(expected_win_id)
+            assert.spy(api_mock.nvim_buf_get_lines).was_called_with(expected_buf_id, -2, -1, false)
+            mock.revert(api_mock)
+            on_close.revert(on_close)
+            buf_request.revert(buf_request)
+            apply_changes.revert(apply_changes)
             make_params.revert(make_params)
         end)
     end)

--- a/lua/tests/renamer_layout_spec.lua
+++ b/lua/tests/renamer_layout_spec.lua
@@ -1,3 +1,4 @@
+local strings = require('renamer.constants').strings
 local renamer = require 'renamer'
 local utils = require 'renamer.utils'
 
@@ -17,6 +18,8 @@ describe('renamer', function()
                 local cursor_col, word_start, win_width = 15, 13, 20
                 local cword = 'test'
                 local expected_width = #cword
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
                 api_mock.nvim_command.returns()
@@ -34,6 +37,7 @@ describe('renamer', function()
 
                 eq(expected_width, opts.opts.width)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 expand.revert(expand)
                 set_cursor.revert(set_cursor)
@@ -44,6 +48,8 @@ describe('renamer', function()
                 local cursor_col, word_start, win_width = 15, 13, 20
                 local cword = 'testing'
                 local expected_width = #cword
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
                 api_mock.nvim_command.returns()
@@ -61,6 +67,7 @@ describe('renamer', function()
 
                 eq(expected_width, opts.opts.width)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 expand.revert(expand)
                 set_cursor.revert(set_cursor)
@@ -73,6 +80,8 @@ describe('renamer', function()
             end)
 
             it('should call `_set_prompt_border_win_style`', function()
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, 2 }
                 api_mock.nvim_command.returns()
@@ -90,6 +99,7 @@ describe('renamer', function()
 
                 assert.spy(set_prompt_border_win_style).was_called_with(1)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
@@ -97,7 +107,9 @@ describe('renamer', function()
             it('should use cursor line for line position if there is enough space below', function()
                 local cursor_line = 1
                 local expected_line_no = 2
-                local expected_line = 'cursor+' .. expected_line_no
+                local expected_line = strings.plenary_popup_cursor_plus .. expected_line_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { cursor_line, 2 }
                 api_mock.nvim_command.returns()
@@ -114,13 +126,16 @@ describe('renamer', function()
 
                 eq(expected_line, opts.opts.line)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
 
             it('should use flip line position if at the end of the screen', function()
                 local expected_line_no = 2
-                local expected_line = 'cursor-' .. expected_line_no
+                local expected_line = strings.plenary_popup_cursor_minus .. expected_line_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, 2 }
                 api_mock.nvim_command.returns()
@@ -137,13 +152,16 @@ describe('renamer', function()
 
                 eq(expected_line, opts.opts.line)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
 
             it('should set the column position at the begining of the cword (cursor column inside word)', function()
                 local expected_col_no = 2
-                local expected_col = 'cursor-' .. expected_col_no
+                local expected_col = strings.plenary_popup_cursor_minus .. expected_col_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, expected_col_no + 1 }
                 api_mock.nvim_command.returns()
@@ -160,6 +178,7 @@ describe('renamer', function()
 
                 eq(expected_col, opts.opts.col)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
@@ -167,7 +186,9 @@ describe('renamer', function()
             it('should set the column position at the begining of the cword (cursor column at word start)', function()
                 local cursor_col = 10
                 local expected_col_no = 1
-                local expected_col = 'cursor-' .. expected_col_no
+                local expected_col = strings.plenary_popup_cursor_minus .. expected_col_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
                 api_mock.nvim_command.returns()
@@ -184,6 +205,7 @@ describe('renamer', function()
 
                 eq(expected_col, opts.opts.col)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
@@ -192,7 +214,9 @@ describe('renamer', function()
                 local cursor_col = 10
                 local word_start = 5
                 local expected_col_no = cursor_col - word_start + 1
-                local expected_col = 'cursor-' .. expected_col_no
+                local expected_col = strings.plenary_popup_cursor_minus .. expected_col_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
                 api_mock.nvim_command.returns()
@@ -209,6 +233,7 @@ describe('renamer', function()
 
                 eq(expected_col, opts.opts.col)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
@@ -219,7 +244,9 @@ describe('renamer', function()
                 local win_width = 20
                 -- no `word_start` as the formula would have `... - word_start ... + word_start`
                 local expected_col_no = cursor_col + 1 + #renamer.title + 4 - win_width + 4
-                local expected_col = 'cursor-' .. expected_col_no
+                local expected_col = strings.plenary_popup_cursor_minus .. expected_col_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
                 api_mock.nvim_command.returns()
@@ -236,6 +263,7 @@ describe('renamer', function()
 
                 eq(expected_col, opts.opts.col)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
@@ -249,7 +277,9 @@ describe('renamer', function()
             it('should use cursor line for line position if there is enough space below', function()
                 local cursor_line = 1
                 local expected_line_no = 1
-                local expected_line = 'cursor+' .. expected_line_no
+                local expected_line = strings.plenary_popup_cursor_plus .. expected_line_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { cursor_line, 2 }
                 api_mock.nvim_command.returns()
@@ -266,13 +296,16 @@ describe('renamer', function()
 
                 eq(expected_line, opts.opts.line)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
 
             it('should use flip line position if at the end of the screen', function()
                 local expected_line_no = 1
-                local expected_line = 'cursor-' .. expected_line_no
+                local expected_line = strings.plenary_popup_cursor_minus .. expected_line_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, 2 }
                 api_mock.nvim_command.returns()
@@ -289,13 +322,16 @@ describe('renamer', function()
 
                 eq(expected_line, opts.opts.line)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
 
             it('should set the column position at the begining of the cword (cursor column inside word)', function()
                 local expected_col_no = 1
-                local expected_col = 'cursor-' .. expected_col_no
+                local expected_col = strings.plenary_popup_cursor_minus .. expected_col_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, expected_col_no + 1 }
                 api_mock.nvim_command.returns()
@@ -312,6 +348,7 @@ describe('renamer', function()
 
                 eq(expected_col, opts.opts.col)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
@@ -319,7 +356,9 @@ describe('renamer', function()
             it('should set the column position at the begining of the cword (cursor column at word start)', function()
                 local cursor_col = 10
                 local expected_col_no = 0
-                local expected_col = 'cursor-' .. expected_col_no
+                local expected_col = strings.plenary_popup_cursor_minus .. expected_col_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
                 api_mock.nvim_command.returns()
@@ -336,6 +375,7 @@ describe('renamer', function()
 
                 eq(expected_col, opts.opts.col)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
@@ -344,7 +384,9 @@ describe('renamer', function()
                 local cursor_col = 10
                 local word_start = 5
                 local expected_col_no = cursor_col - word_start + 1
-                local expected_col = 'cursor-' .. expected_col_no
+                local expected_col = strings.plenary_popup_cursor_minus .. expected_col_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
                 api_mock.nvim_command.returns()
@@ -361,6 +403,7 @@ describe('renamer', function()
 
                 eq(expected_col, opts.opts.col)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)
@@ -371,7 +414,9 @@ describe('renamer', function()
                 local win_width = 20
                 -- no `word_start` as the formula would have `... - word_start ... + word_start`
                 local expected_col_no = cursor_col + 1 + #renamer.title + 4 - win_width
-                local expected_col = 'cursor-' .. expected_col_no
+                local expected_col = strings.plenary_popup_cursor_minus .. expected_col_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
                 api_mock.nvim_win_get_cursor.returns { 1, cursor_col }
                 api_mock.nvim_command.returns()
@@ -388,6 +433,7 @@ describe('renamer', function()
 
                 eq(expected_col, opts.opts.col)
                 mock.revert(api_mock)
+                mock.revert(lsp_mock)
                 document_highlight.revert(document_highlight)
                 set_cursor.revert(set_cursor)
             end)

--- a/lua/tests/renamer_rename_spec.lua
+++ b/lua/tests/renamer_rename_spec.lua
@@ -16,8 +16,32 @@ describe('renamer', function()
             renamer.setup()
         end)
 
+        it('should not allow renaming if no LSP client is attached to the current buffer (nil value)', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns(nil)
+            local create = stub(popup, 'create')
+
+            renamer.rename()
+
+            assert.spy(create).called_at_most(0)
+            mock.revert(lsp_mock)
+        end)
+
+        it('should not allow renaming if no LSP client is attached (less than 1 client)', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns {}
+            local create = stub(popup, 'create')
+
+            renamer.rename()
+
+            assert.spy(create).called_at_most(0)
+            mock.revert(lsp_mock)
+        end)
+
         it('should not allow renaming if word start is nil', function()
             local expected_cword = 'test'
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns()
             api_mock.nvim_win_get_height.returns(15)
@@ -33,10 +57,13 @@ describe('renamer', function()
 
             assert.spy(create).called_at_most(0)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
         end)
 
         it('should fallback to `vim.fn.input()` if width is too short (with border)', function()
             local expected_cword = 'test'
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns()
             api_mock.nvim_win_get_height.returns(15)
@@ -60,6 +87,7 @@ describe('renamer', function()
             assert.spy(rename).called_at_most(1)
             assert.spy(create).called_at_most(0)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
@@ -67,6 +95,8 @@ describe('renamer', function()
         it('should fallback to `vim.fn.input()` if width is too short (without border)', function()
             renamer.setup { border = false }
             local expected_cword = 'test'
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns()
             api_mock.nvim_win_get_height.returns(15)
@@ -90,12 +120,15 @@ describe('renamer', function()
             assert.spy(rename).called_at_most(1)
             assert.spy(create).called_at_most(0)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should fallback to `vim.fn.input()` if height is too short (with border)', function()
             local expected_cword = 'test'
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns()
             api_mock.nvim_win_get_height.returns(3)
@@ -119,6 +152,7 @@ describe('renamer', function()
             assert.spy(rename).called_at_most(1)
             assert.spy(create).called_at_most(0)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
@@ -126,6 +160,8 @@ describe('renamer', function()
         it('should fallback to `vim.fn.input()` if height is too short (without border)', function()
             renamer.setup { border = false }
             local expected_cword = 'test'
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns()
             api_mock.nvim_win_get_height.returns(3)
@@ -149,6 +185,7 @@ describe('renamer', function()
             assert.spy(rename).called_at_most(1)
             assert.spy(create).called_at_most(0)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
@@ -163,6 +200,8 @@ describe('renamer', function()
                 },
             }
             local expected_cword = 'test'
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns()
             api_mock.nvim_win_get_height.returns(15)
@@ -186,6 +225,7 @@ describe('renamer', function()
             assert.spy(rename).called_at_most(1)
             assert.spy(create).called_at_most(0)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
@@ -201,6 +241,8 @@ describe('renamer', function()
                 },
             }
             local expected_cword = 'test'
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns()
             api_mock.nvim_win_get_height.returns(15)
@@ -224,6 +266,7 @@ describe('renamer', function()
             assert.spy(rename).called_at_most(1)
             assert.spy(create).called_at_most(0)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
@@ -231,6 +274,8 @@ describe('renamer', function()
         it('should use `vim.fn.input()` if "with_popup" is `false`', function()
             renamer.setup { with_popup = false }
             local expected_cword = 'test'
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns()
             api_mock.nvim_win_get_height.returns(15)
@@ -254,6 +299,7 @@ describe('renamer', function()
             assert.spy(rename).called_at_most(1)
             assert.spy(create).called_at_most(0)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
@@ -261,6 +307,8 @@ describe('renamer', function()
         it('should not rename if no input is received ("with_popup" is `true`)', function()
             renamer.setup { with_popup = false }
             local expected_cword = 'test'
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns()
             api_mock.nvim_win_get_height.returns(15)
@@ -283,12 +331,15 @@ describe('renamer', function()
             assert.spy(rename).called_at_most(0)
             assert.spy(create).called_at_most(0)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should call `utils.get_word_boundaries_in_line`', function()
             local expected_cword, expected_line, expected_col = 'test', 1, 2
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_command.returns()
             api_mock.nvim_win_get_cursor.returns { 1, expected_col }
@@ -308,11 +359,14 @@ describe('renamer', function()
 
             assert.spy(get_word_boundaries_in_line).was_called_with(expected_line, expected_cword, expected_col + 1)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should highlight references if `show_refs` is `true`', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_command.returns()
             api_mock.nvim_buf_line_count.returns(1)
@@ -331,11 +385,14 @@ describe('renamer', function()
 
             assert.spy(document_highlight).was_called()
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should not highlight references if `show_refs` is not `true`', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_command.returns()
             api_mock.nvim_buf_line_count.returns(1)
@@ -355,11 +412,14 @@ describe('renamer', function()
 
             assert.spy(document_highlight).called_less_than(1)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should call `_setup_window`', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_command.returns()
             api_mock.nvim_buf_line_count.returns(1)
@@ -378,11 +438,14 @@ describe('renamer', function()
 
             assert.spy(setup_window).was_called()
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should call `_set_prompt_win_style`', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_command.returns()
@@ -401,11 +464,14 @@ describe('renamer', function()
 
             assert.spy(set_prompt_win_style).was_called()
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should call `_create_autocmds`', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_command.returns()
@@ -424,6 +490,7 @@ describe('renamer', function()
 
             assert.spy(create_autocms).was_called()
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
@@ -459,6 +526,8 @@ describe('renamer', function()
             }
             local expected_border_opts = {}
             local expected_buf_id = 123
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns { expected_line_no, expected_col_no }
             api_mock.nvim_command.returns()
@@ -477,11 +546,14 @@ describe('renamer', function()
             eq(expected_opts, opts.opts)
             eq(expected_border_opts, opts.border_opts)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should call `mappings.register_bindings`', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_command.returns()
@@ -501,11 +573,14 @@ describe('renamer', function()
 
             assert.spy(register_bindings).was_called()
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should default to "empty" being `false` if not specified', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_command.returns()
@@ -529,12 +604,15 @@ describe('renamer', function()
 
             eq(expected_word, word)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             expand.revert(expand)
             set_cursor.revert(set_cursor)
         end)
 
         it('should default to "empty" being `false` if nil', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_command.returns()
@@ -557,11 +635,14 @@ describe('renamer', function()
 
             eq(expected_word, word)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
 
         it('should be empty if "empty" is `true`', function()
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_command.returns()
@@ -586,6 +667,7 @@ describe('renamer', function()
 
             eq(expected_word, word)
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
             set_cursor.revert(set_cursor)
         end)
@@ -593,6 +675,8 @@ describe('renamer', function()
         it('should set cursor to the end of the popup word (no padding)', function()
             local buf_line = 'abc'
             local expected_line, expected_col = 1, #buf_line
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_command.returns()
@@ -610,6 +694,7 @@ describe('renamer', function()
 
             assert.spy(api_mock.nvim_win_set_cursor).was_called_with(0, { expected_line, expected_col })
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
         end)
 
@@ -617,6 +702,8 @@ describe('renamer', function()
             local padding = { top = 4, left = 2, right = 2 }
             local buf_line = '  abc  '
             local expected_line, expected_col = 1 + padding.top, #buf_line - padding.right
+            local lsp_mock = mock(vim.lsp, true)
+            lsp_mock.buf_get_clients.returns { {} }
             local api_mock = mock(vim.api, true)
             api_mock.nvim_win_get_cursor.returns { 1, 2 }
             api_mock.nvim_command.returns()
@@ -637,6 +724,7 @@ describe('renamer', function()
 
             assert.spy(api_mock.nvim_win_set_cursor).was_called_with(0, { expected_line, expected_col })
             mock.revert(api_mock)
+            mock.revert(lsp_mock)
             document_highlight.revert(document_highlight)
         end)
     end)


### PR DESCRIPTION
# Motivation

Prevent renaming when no LSP client is attached to the current buffer.
Overhaul tests to cover the renaming logic.

Closes: GH-96

## Proposed changes

- update `renamer.rename()` to only allow renaming when an LSP client is attached

### Test plan

Existing tests are updated to cover the new functionality and new tests are added for the overhaul covering `renamer._lsp_rename()`.
