### PR TITLE
feat: add customizable min and max width

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ require('renamer').setup {
         bottom = 0,
         right = 0,
     },
+    -- The minimum width of the popup
+    minwidth = 15,
+    -- The maximum width of the popup
+    maxwidth = 45,
     -- Whether or not to shown a border around the popup
     border = true,
     -- The characters which make up the border

--- a/doc/renamer.txt
+++ b/doc/renamer.txt
@@ -43,6 +43,10 @@ renamer.setup({opts})
             bottom = 0,
             right = 0,
         },
+        -- The minimum width of the popup
+        minwidth = 15,
+        -- The maximum width of the popup
+        maxwidth = 45,
         -- Whether or not to shown a border around the popup
         border = true,
         -- The characters which make up the border
@@ -83,6 +87,10 @@ renamer.setup({opts})
                                     above/right/below/left
                                     (default: { top = 0, left = 0, bottom = 0,
                                     right = 0 })
+        {minwidth}      (integer)   minimum width that the popup should have
+                                    (default: 15)
+        {maxwidth}      (integer)   maximum width that the popup should have
+                                    (default: 45)
         {border}        (boolean)   defines whether or not to draw the border
                                     (default: true)
         {border_chars}  (list)      list of characters to use for the border,

--- a/lua/renamer/defaults.lua
+++ b/lua/renamer/defaults.lua
@@ -3,6 +3,8 @@ local mappings = require 'renamer.mappings'
 --- @class Defaults
 --- @field public title string
 --- @field public padding table
+--- @field public minwidth integer
+--- @field public maxwidth integer
 --- @field public border boolean
 --- @field public border_chars string[]
 --- @field public show_refs boolean
@@ -20,6 +22,10 @@ local defaults = {
         bottom = 0,
         right = 0,
     },
+    -- The minimum width of the popup
+    minwidth = 15,
+    -- The maximum width of the popup
+    maxwidth = 45,
     -- Whether or not to shown a border around the popup
     border = true,
     -- The characters which make up the border

--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -11,6 +11,8 @@ local mappings = require 'renamer.mappings'
 --- @class Renamer
 --- @field public title string
 --- @field public padding integer[]
+--- @field public minwidth integer
+--- @field public maxwidth integer
 --- @field public border boolean
 --- @field public border_chars string[]
 --- @field public show_refs boolean
@@ -37,6 +39,10 @@ local renamer = {}
 ---         bottom = 0,
 ---         right = 0,
 ---     },
+---     -- The minimum width of the popup
+---     minwidth = 15,
+---     -- The maximum width of the popup
+---     maxwidth = 45,
 ---     -- Whether or not to shown a border around the popup
 ---     border = true,
 ---     -- The characters which make up the border
@@ -77,6 +83,8 @@ function renamer.setup(opts)
         bottom = utils.get_value_or_default(opts.padding, 'bottom', defaults.padding.bottom),
         right = utils.get_value_or_default(opts.padding, 'right', defaults.padding.right),
     }
+    renamer.minwidth = utils.get_value_or_default(opts, 'minwidth', defaults.minwidth)
+    renamer.maxwidth = utils.get_value_or_default(opts, 'maxwidth', defaults.maxwidth)
     renamer.border = utils.get_value_or_default(opts, 'border', defaults.border)
     renamer.border_chars = utils.get_value_or_default(opts, 'border_chars', defaults.border_chars)
     renamer.show_refs = utils.get_value_or_default(opts, 'show_refs', defaults.show_refs)
@@ -260,8 +268,8 @@ function renamer._create_default_popup_opts(cword)
         borderchars = renamer.border_chars,
         highlight = strings.highlight_normal,
         borderhighlight = strings.highlight_border,
-        minwidth = 15,
-        maxwidth = 45,
+        minwidth = renamer.minwidth,
+        maxwidth = renamer.maxwidth,
         minheight = 1,
         posinvert = false,
         cursor_line = true,

--- a/lua/tests/defaults_spec.lua
+++ b/lua/tests/defaults_spec.lua
@@ -11,6 +11,8 @@ describe('defaults', function()
                 bottom = 0,
                 right = 0,
             },
+            minwidth = 15,
+            maxwidth = 45,
             border = true,
             border_chars = { '─', '│', '─', '│', '╭', '╮', '╯', '╰' },
             show_refs = true,


### PR DESCRIPTION
# Motivation

Add `minwidth` and `maxwidth` default and setup parameters in order to allow for customizable size of the popup.

Closes: GH-101

## Proposed changes

- add `minwidth` and `maxwith` to `lua/renamer/defaults.lua`
- add `minwidth` and `maxwith` to `lua/renamer/init.lua` (in `setup(...)`)
- update docs

### Test plan

Existing tests cover the new changes.
