### PR TITLE
fix(layout): popup position when low number of lines

### DIFF
--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -146,7 +146,8 @@ function renamer.rename(opts)
         return
     end
     local prompt_col_no, prompt_line_no = col - word_start + 1, 2
-    local lines_from_win_end = vim.api.nvim_buf_line_count(0) - line
+    local line_count = vim.api.nvim_buf_line_count(0)
+    local lines_from_win_end = line_count - line
     local width = 0
 
     if renamer.title then
@@ -158,7 +159,7 @@ function renamer.rename(opts)
     if not (renamer.border == true) then
         prompt_line_no = 1
     end
-    if lines_from_win_end < prompt_line_no + 1 then
+    if lines_from_win_end < prompt_line_no + 1 and line_count >= win_height - 1 then
         prompt_line_no = -prompt_line_no
     end
     if word_start + width >= win_width then

--- a/lua/tests/renamer_layout_spec.lua
+++ b/lua/tests/renamer_layout_spec.lua
@@ -137,9 +137,35 @@ describe('renamer', function()
                 local lsp_mock = mock(vim.lsp, true)
                 lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
-                api_mock.nvim_win_get_cursor.returns { 1, 2 }
+                api_mock.nvim_win_get_cursor.returns { 9, 2 }
                 api_mock.nvim_command.returns()
-                api_mock.nvim_buf_line_count.returns(1)
+                api_mock.nvim_buf_line_count.returns(10)
+                api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
+                stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
+                local document_highlight = stub(renamer, '_document_highlight').returns()
+                local set_cursor = stub(renamer, '_set_cursor_to_popup_end')
+                stub(popup, 'create').returns(1, {})
+
+                local _, opts = renamer.rename()
+
+                eq(expected_line, opts.opts.line)
+                mock.revert(api_mock)
+                mock.revert(lsp_mock)
+                document_highlight.revert(document_highlight)
+                set_cursor.revert(set_cursor)
+            end)
+
+            it('should not flip line pos if there is enough space after the last line', function()
+                local expected_line_no = 2
+                local expected_line = strings.plenary_popup_cursor_plus .. expected_line_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
+                local api_mock = mock(vim.api, true)
+                api_mock.nvim_win_get_cursor.returns { 5, 2 }
+                api_mock.nvim_command.returns()
+                api_mock.nvim_buf_line_count.returns(5)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
                 api_mock.nvim_win_get_height.returns(10)
@@ -307,9 +333,35 @@ describe('renamer', function()
                 local lsp_mock = mock(vim.lsp, true)
                 lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
-                api_mock.nvim_win_get_cursor.returns { 1, 2 }
+                api_mock.nvim_win_get_cursor.returns { 10, 2 }
                 api_mock.nvim_command.returns()
-                api_mock.nvim_buf_line_count.returns(1)
+                api_mock.nvim_buf_line_count.returns(10)
+                api_mock.nvim_get_mode.returns {}
+                api_mock.nvim_win_get_width.returns(100)
+                api_mock.nvim_win_get_height.returns(10)
+                stub(utils, 'get_word_boundaries_in_line').returns(1, 2)
+                local set_cursor = stub(renamer, '_set_cursor_to_popup_end')
+                local document_highlight = stub(renamer, '_document_highlight').returns()
+                stub(popup, 'create').returns(1, {})
+
+                local _, opts = renamer.rename()
+
+                eq(expected_line, opts.opts.line)
+                mock.revert(api_mock)
+                mock.revert(lsp_mock)
+                document_highlight.revert(document_highlight)
+                set_cursor.revert(set_cursor)
+            end)
+
+            it('should not flip line pos if there is enough space after the last line', function()
+                local expected_line_no = 1
+                local expected_line = strings.plenary_popup_cursor_plus .. expected_line_no
+                local lsp_mock = mock(vim.lsp, true)
+                lsp_mock.buf_get_clients.returns { {} }
+                local api_mock = mock(vim.api, true)
+                api_mock.nvim_win_get_cursor.returns { 5, 2 }
+                api_mock.nvim_command.returns()
+                api_mock.nvim_buf_line_count.returns(5)
                 api_mock.nvim_get_mode.returns {}
                 api_mock.nvim_win_get_width.returns(100)
                 api_mock.nvim_win_get_height.returns(10)


### PR DESCRIPTION
# Motivation

Fix an issue that made the popup render improperly when the file contained a low number of lines (< 5), but the window high was high enough.

Closes: GH-105

## Proposed changes

- flip line position only if there is not enough space to draw the popup below in the window

### Test plan

Existing tests were updated to validate the new functionality and new ones were added in `lua/tests/renamer_layout_spec.lua`.
