### PR TITLE
fix(rename): responses without `changes` break `qflist`

### DIFF
--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -391,7 +391,7 @@ function renamer._lsp_rename(word, pos)
             renamer._apply_workspace_edit(resp)
 
             if renamer.with_qf_list then
-                local changes = resp.changes
+                local changes = resp.changes or {}
                 if resp.documentChanges then
                     for _, change in ipairs(resp.documentChanges) do
                         if change.textDocument and change.textDocument.uri then


### PR DESCRIPTION
# Motivation

Add default value if `resp.changes` is `nil`, in order to not break response handling if an LSP response does not provide that field.

Closes: GH-106

## Proposed changes

- add default value of `{}` if `resp.changes` is `nil` in `_lsp_rename(...)`

### Test plan

Not sure what the proper way to implement a test specifically for this is. TBD.
