### PR TITLE
fix: popup not showing if renamed word appears twice

### DIFF
--- a/lua/renamer/utils.lua
+++ b/lua/renamer/utils.lua
@@ -31,8 +31,10 @@ function utils.get_word_boundaries_in_line(line, word, line_pos)
         if
             word_start
             and word_end
-            and math.abs(line_pos - word_start) < math.abs(line_pos - closest_word_start)
-            and math.abs(word_end - line_pos) < math.abs(closest_word_end - line_pos)
+            and (
+                math.abs(line_pos - word_start) < math.abs(line_pos - closest_word_start)
+                or math.abs(word_end - line_pos) < math.abs(closest_word_end - line_pos)
+            )
         then
             closest_word_start, closest_word_end = word_start, word_end
         end


### PR DESCRIPTION
# Motivation

If the word to be renamed is present or is in the body of another word on the same line, the popup could've been prevented from being shown, due to the use of an `and` condition instead of an `or` one in `utils.get_word_boundaries_in_line(...)`.

Closes: GH-113

## Proposed changes

- change `and` condition to `or`

### Test plan

Existing tests cover the functionality.
