### PR TITLE
fix: popup having `sidescrolloff` if set

### DIFF
--- a/lua/renamer/constants.lua
+++ b/lua/renamer/constants.lua
@@ -15,6 +15,7 @@ local strings = {
     buf_delete_command_template = 'silent! bdelete! %s',
     win_opt_wrap = 'wrap',
     win_opt_winblend = 'winblend',
+    win_opt_sidescrolloff = 'sidescrolloff',
     buf_opt_buflisted = 'buflisted',
     autocmd_buf_leave_template = 'autocmd BufLeave,WinLeave <buffer> ++nested ++once :silent lua require("renamer").on_close(%s)',
     augroup_start = 'augroup RenamerInsert',

--- a/lua/renamer/init.lua
+++ b/lua/renamer/init.lua
@@ -154,7 +154,7 @@ function renamer.rename(opts)
         width = #renamer.title + 4
     end
     if width >= win_width or #cword > width then
-        width = #cword
+        width = #cword + 1
     end
     if not (renamer.border == true) then
         prompt_line_no = 1
@@ -306,6 +306,7 @@ function renamer._setup_window(prompt_win_id)
 
     vim.api.nvim_win_set_option(prompt_win_id, strings.win_opt_wrap, false)
     vim.api.nvim_win_set_option(prompt_win_id, strings.win_opt_winblend, 0)
+    vim.api.nvim_win_set_option(prompt_win_id, strings.win_opt_sidescrolloff, 0)
 
     vim.api.nvim_command(strings.startinsert_command)
     renamer._create_autocmds(prompt_win_id)

--- a/lua/tests/renamer_layout_spec.lua
+++ b/lua/tests/renamer_layout_spec.lua
@@ -17,7 +17,7 @@ describe('renamer', function()
                 renamer.setup { title = string.rep('a', 16) }
                 local cursor_col, word_start, win_width = 15, 13, 20
                 local cword = 'test'
-                local expected_width = #cword
+                local expected_width = #cword + 1
                 local lsp_mock = mock(vim.lsp, true)
                 lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)
@@ -47,7 +47,7 @@ describe('renamer', function()
                 renamer.setup { title = 'a' }
                 local cursor_col, word_start, win_width = 15, 13, 20
                 local cword = 'testing'
-                local expected_width = #cword
+                local expected_width = #cword + 1
                 local lsp_mock = mock(vim.lsp, true)
                 lsp_mock.buf_get_clients.returns { {} }
                 local api_mock = mock(vim.api, true)


### PR DESCRIPTION
# Motivation

The popup would have the `sidescrolloff` set in Neovim's config, leading to words being truncated and looking off. Now the setting is put to 0 for the popup window to prevent the issue.

There was also an issue with the width of the popup if the word to be renamed was larger than the default width, which lead to 1 character being truncated. This was fixed by adding `+ 1` to the word length.

Closes: GH-101

## Proposed changes

- set `sidescrolloff` to 0 in `_setup_window`
- add `+ 1` to the current word length when setting the popup width based on it
- add constant for `sidescrolloff`

### Test plan

Existing tests are updated to validate the new functionality.
