### PR TITLE
fix(submit): trim new word before using

### DIFF
--- a/lua/tests/renamer_rename_handler_spec.lua
+++ b/lua/tests/renamer_rename_handler_spec.lua
@@ -9,8 +9,15 @@ local spy = require 'luassert.spy'
 local eq = assert.are.same
 
 describe('_rename_handler', function()
+    local log = nil
+
     before_each(function()
         renamer.setup { with_qf_list = false }
+        log = mock(renamer._log)
+    end)
+
+    after_each(function()
+        mock.revert(log)
     end)
 
     it('should not apply changes if error is received', function()


### PR DESCRIPTION
# Motivation

Trim the new word of leading and ending spaces before using it to rename. This should prevent padding from being used in the final name, as well as making it a bit more logic and consistent with most IDEs.

Fixes: GH-119

## Proposed changes

- trim `new_word` spaces on submit (as seen in [this StackOverflow question](https://stackoverflow.com/a/51181334))
- radd a test case to validate the change

### Test plan

Existing tests are updated and a new test case is added in `lua/tests/rename_close_spec.lua`.

